### PR TITLE
feat: wallpaper engine support

### DIFF
--- a/.config/ags/constants/settings.constants.ts
+++ b/.config/ags/constants/settings.constants.ts
@@ -325,6 +325,174 @@ export const defaultSettings: Settings = {
   wallpaperSwitcher: {
     category: "defaults/sfw",
   },
+  // Wallpaper Engine renderer (kirie). Everything the engine accepts live is
+  // sent over its control socket as it changes; the rest is handed to the next
+  // engine launch by the wallpaper daemon, hence the "restart" tooltips.
+  wallpaperEngine: {
+    fps: {
+      name: "Frame Rate",
+      value: 30,
+      type: "int",
+      min: 1,
+      max: 240,
+      tooltip: "Frames per second the wallpaper is rendered at.",
+    },
+    batteryFps: {
+      name: "Battery Frame Rate",
+      value: 10,
+      type: "int",
+      min: 0,
+      max: 240,
+      tooltip:
+        "Frame rate used while running on battery.\n0 keeps the normal frame rate.",
+    },
+    renderScale: {
+      name: "Render Scale",
+      value: 1,
+      type: "float",
+      min: 0.5,
+      max: 2,
+      tooltip:
+        "Resolution the wallpaper renders at, relative to the screen.\nBelow 1 costs quality and saves GPU.",
+    },
+    playbackSpeed: {
+      name: "Playback Speed",
+      value: 1,
+      type: "float",
+      min: 0.1,
+      max: 2,
+      tooltip: "Animation speed (1 = normal, 0.5 = half, 2 = double).",
+    },
+    volume: {
+      name: "Volume",
+      value: 15,
+      type: "int",
+      min: 0,
+      max: 128,
+      tooltip: "Volume of wallpapers that carry sound.",
+    },
+    mute: {
+      name: "Mute",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 0,
+      tooltip: "Silence wallpaper audio without pausing the wallpaper.",
+    },
+    audioDevice: {
+      name: "Audio Source",
+      value: "",
+      type: "select",
+      min: 0,
+      max: 0,
+      tooltip:
+        "Source the audio-reactive wallpapers listen to.\nEmpty follows the default output.",
+    },
+    noAutomute: {
+      name: "Keep Sound With Other Audio",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 0,
+      tooltip:
+        "Keep wallpaper audio playing while something else is making sound.",
+    },
+    noAudioProcessing: {
+      name: "Disable Audio Reactivity",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 0,
+      tooltip:
+        "Stop capturing system audio entirely.\nApplies when the engine restarts.",
+    },
+    scaling: {
+      name: "Scaling",
+      value: "default",
+      type: "select",
+      min: 0,
+      max: 0,
+      tooltip: "How the wallpaper is fitted to the screen.",
+    },
+    clamp: {
+      name: "Edge Handling",
+      value: "clamp",
+      type: "select",
+      min: 0,
+      max: 0,
+      tooltip: "What is drawn beyond the wallpaper's edges.",
+    },
+    layer: {
+      name: "Layer",
+      value: "bottom",
+      type: "select",
+      min: 0,
+      max: 0,
+      tooltip:
+        "Which desktop layer the wallpaper is drawn on.\nApplies when the engine restarts.",
+    },
+    gpu: {
+      name: "GPU",
+      value: "auto",
+      type: "select",
+      min: 0,
+      max: 0,
+      tooltip:
+        "Which GPU renders the wallpaper.\nApplies when the engine restarts.",
+    },
+    assetsDir: {
+      name: "Assets Directory",
+      value: "",
+      type: "string",
+      min: 0,
+      max: 512,
+      tooltip:
+        "Wallpaper Engine's builtin assets folder.\nEmpty detects it automatically. Applies when the engine restarts.",
+    },
+    disableMouse: {
+      name: "Disable Mouse Interaction",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 0,
+      tooltip: "Stop wallpapers from reacting to the pointer.",
+    },
+    disableParallax: {
+      name: "Disable Parallax",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 0,
+      tooltip: "Stop the camera from following the pointer.",
+    },
+    disableParticles: {
+      name: "Disable Particles",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 0,
+      tooltip:
+        "Skip particle systems, the most expensive part of many scenes.\nApplies when the engine restarts.",
+    },
+    noFullscreenPause: {
+      name: "Keep Rendering Under Fullscreen",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 0,
+      tooltip:
+        "Keep the wallpaper running while a window is fullscreen.\nCosts GPU for something nobody can see.",
+    },
+    fullscreenPauseOnlyActive: {
+      name: "Pause Only For The Active Window",
+      value: false,
+      type: "bool",
+      min: 0,
+      max: 0,
+      tooltip:
+        "Pause only when the fullscreen window is the focused one.\nApplies when the engine restarts.",
+    },
+  },
   apiKeys: {
     openrouter: {
       user: {

--- a/.config/ags/constants/settings.constants.ts
+++ b/.config/ags/constants/settings.constants.ts
@@ -325,6 +325,17 @@ export const defaultSettings: Settings = {
   wallpaperSwitcher: {
     category: "defaults/sfw",
   },
+  wallpaper: {
+    mode: {
+      name: "Wallpaper Mode",
+      value: "workspace",
+      type: "select",
+      min: 0,
+      max: 0,
+      tooltip:
+        "Per Workspace: every workspace keeps its own wallpaper.\nGlobal: one wallpaper for all of them.",
+    },
+  },
   // Wallpaper Engine renderer (kirie). Everything the engine accepts live is
   // sent over its control socket as it changes; the rest is handed to the next
   // engine launch by the wallpaper daemon, hence the "restart" tooltips.

--- a/.config/ags/interfaces/settings.interface.ts
+++ b/.config/ags/interfaces/settings.interface.ts
@@ -114,6 +114,27 @@ export interface Settings {
   wallpaperSwitcher: {
     category: string;
   };
+  wallpaperEngine: {
+    fps: AGSSetting;
+    batteryFps: AGSSetting;
+    renderScale: AGSSetting;
+    playbackSpeed: AGSSetting;
+    volume: AGSSetting;
+    mute: AGSSetting;
+    audioDevice: AGSSetting;
+    noAutomute: AGSSetting;
+    noAudioProcessing: AGSSetting;
+    scaling: AGSSetting;
+    clamp: AGSSetting;
+    layer: AGSSetting;
+    gpu: AGSSetting;
+    assetsDir: AGSSetting;
+    disableMouse: AGSSetting;
+    disableParallax: AGSSetting;
+    disableParticles: AGSSetting;
+    noFullscreenPause: AGSSetting;
+    fullscreenPauseOnlyActive: AGSSetting;
+  };
   apiKeys: {
     openrouter: {
       user: AGSSetting;

--- a/.config/ags/interfaces/settings.interface.ts
+++ b/.config/ags/interfaces/settings.interface.ts
@@ -114,6 +114,9 @@ export interface Settings {
   wallpaperSwitcher: {
     category: string;
   };
+  wallpaper: {
+    mode: AGSSetting;
+  };
   wallpaperEngine: {
     fps: AGSSetting;
     batteryFps: AGSSetting;

--- a/.config/ags/scripts/get-wallpapers.sh
+++ b/.config/ags/scripts/get-wallpapers.sh
@@ -76,12 +76,28 @@ if [ "$1" == "--current" ]; then
     else
         monitor=$2
     fi
+    monitor_conf="$wallpaper_config/$monitor/defaults.conf"
+
+    # In global mode one wallpaper covers every workspace, so that is the only
+    # entry to report; otherwise report the per-workspace slots in order.
+    mode="$(grep '^mode=' "$monitor_conf" 2>/dev/null | cut -d'=' -f2- | head -n 1)"
+    [ "$mode" = "global" ] || mode="workspace"
+
     # Read the file line by line
     while IFS='=' read -r key path; do
+        if [ "$mode" = "global" ]; then
+            [ "$key" = "global" ] || continue
+        else
+            case "$key" in
+                w-*) ;;
+                *) continue ;;
+            esac
+        fi
+
         # Trim any whitespace from the path and add to the array
         path=$(echo "$path" | sed "s~^\$HOME~$HOME~" | xargs)
         wallpaper_paths+=("\"$path\"")
-    done <"$wallpaper_config/$monitor/defaults.conf"
+    done <"$monitor_conf"
 
 else
 

--- a/.config/ags/scss/widgets/wallpaper-switcher.scss
+++ b/.config/ags/scss/widgets/wallpaper-switcher.scss
@@ -100,7 +100,72 @@
     }
   }
 
+  // Popovers float over a busy panel of sliders and colours, so they get a
+  // solid ground and a border of their own: at the shell's usual translucency
+  // the choice list read as text printed on top of the rows behind it.
+  //
+  // The background has to go on `> contents` — GTK4's popover paints there,
+  // not on the widget node, so styling only the class left it transparent.
+  .property-combo,
+  .color-picker {
+    popover > contents {
+      background: $background;
+      border: 1px solid $background-secondary;
+      border-radius: 10px;
+      box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.55);
+      padding: 6px;
+    }
+
+    popover > arrow {
+      background: $background;
+      border: 1px solid $background-secondary;
+    }
+  }
+
   .property-combo .popover {
-    @include module;
+    background: transparent;
+    min-width: 140px;
+
+    button {
+      padding: 6px 12px;
+      border-radius: 6px;
+      background: transparent;
+
+      &:hover {
+        background: $background-secondary;
+      }
+
+      // The value in force, so the list says which one is current rather than
+      // leaving it to be inferred from the button that opened it.
+      &.selected {
+        background: $secondary;
+        color: $background;
+        font-weight: bold;
+      }
+    }
+  }
+
+  // The swatch is the whole button: a menubutton's usual padding around a
+  // 34x20 colour block reads as a grey button that happens to be tinted.
+  .color-picker {
+    padding: 0;
+    min-height: 0;
+    min-width: 0;
+
+    .color-swatch {
+      border-radius: 4px;
+      border: 1px solid rgba(255, 255, 255, 0.25);
+    }
+  }
+
+  .color-picker-popover {
+    // The wheel supplies its own colour; the popover only has to not tint it.
+    background: transparent;
+    padding: 4px;
+
+    entry {
+      border-radius: 6px;
+      padding: 4px 8px;
+    }
   }
 }

--- a/.config/ags/scss/widgets/wallpaper-switcher.scss
+++ b/.config/ags/scss/widgets/wallpaper-switcher.scss
@@ -388,16 +388,8 @@
   }
 }
 
-// Steam mark + magnifier on the Workshop button. The lens rides small and low
-// so the pair reads as one badge rather than two icons in a row.
+// Steam's mark on the Workshop button, sized to sit level with the gear and
+// shuffle icons either side of it.
 .workshop-icon {
-  .steam {
-    font-size: 1.05em;
-  }
-
-  .lens {
-    font-size: 0.72em;
-    opacity: 0.85;
-    margin-top: 4px;
-  }
+  font-size: 1.15em;
 }

--- a/.config/ags/scss/widgets/wallpaper-switcher.scss
+++ b/.config/ags/scss/widgets/wallpaper-switcher.scss
@@ -248,6 +248,14 @@
     padding: 6px;
   }
 
+  .filter-search {
+    margin: 2px 4px 0 4px;
+    padding: 3px 8px;
+    border-radius: 6px;
+    font-size: 0.85em;
+    min-height: 0;
+  }
+
   .workshop-filter .popover button,
   .workshop-sort .popover button {
     padding: 4px 12px;

--- a/.config/ags/scss/widgets/wallpaper-switcher.scss
+++ b/.config/ags/scss/widgets/wallpaper-switcher.scss
@@ -186,9 +186,9 @@
   .workshop-card {
     // Fixed width, or a long title stretches its column and the grid stops
     // being a grid.
-    min-width: 190px;
-    padding: 6px;
-    border-radius: 10px;
+    min-width: 148px;
+    padding: 4px;
+    border-radius: 8px;
     background: $background-semi-transparent;
 
     &:hover {
@@ -202,16 +202,38 @@
     // so the grid does not reflow as previews come in. Square, because that
     // is the shape Steam serves.
     background: $background-secondary;
-    min-height: 190px;
-    min-width: 190px;
+    min-height: 148px;
+    min-width: 148px;
   }
 
+  // These are dropdowns, and they have to look like it: as bare labels in a
+  // row they read as a heading strip rather than as controls.
   .workshop-filter,
+  .workshop-sort,
   .clear-filters,
   .adult {
-    padding: 2px 10px;
-    border-radius: 6px;
-    font-size: 0.9em;
+    padding: 2px 8px;
+    border-radius: 5px;
+    font-size: 0.82em;
+    min-height: 0;
+    background: $background-secondary;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+
+    &:hover {
+      border-color: rgba(255, 255, 255, 0.3);
+    }
+  }
+
+  .chevron {
+    opacity: 0.55;
+    font-size: 0.8em;
+  }
+
+  // A group with a tag in force is part of the current query, so it stops
+  // looking like the rest of the row.
+  .workshop-filter .chosen {
+    color: $secondary;
+    font-weight: bold;
   }
 
   .workshop-filter popover > contents,
@@ -243,12 +265,12 @@
 
   .workshop-title {
     font-weight: bold;
+    font-size: 0.88em;
   }
 
-  .workshop-kind,
   .workshop-meta {
-    opacity: 0.7;
-    font-size: 0.85em;
+    opacity: 0.65;
+    font-size: 0.78em;
   }
 
   .workshop-warning {
@@ -257,8 +279,9 @@
   }
 
   .subscribe {
-    padding: 4px 10px;
-    border-radius: 6px;
+    padding: 2px 8px;
+    border-radius: 5px;
+    font-size: 0.85em;
 
     // An item already on disk is one click from being shown, so it stops
     // looking like a download.
@@ -273,4 +296,40 @@
   }
 
 
+}
+
+// Right-click menu on a wallpaper: apply, copy, open, and the one entry that
+// takes something away, marked so it cannot be hit by accident.
+.wallpaper-menu {
+  > contents {
+    background: $background;
+    border: 1px solid $background-secondary;
+    border-radius: 10px;
+    box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.55);
+    padding: 6px;
+  }
+
+  .popover {
+    background: transparent;
+    min-width: 170px;
+  }
+
+  button {
+    padding: 5px 12px;
+    border-radius: 6px;
+    background: transparent;
+
+    &:hover {
+      background: $background-secondary;
+    }
+
+    &.destructive {
+      color: $red;
+
+      &:hover {
+        background: $red;
+        color: $background;
+      }
+    }
+  }
 }

--- a/.config/ags/scss/widgets/wallpaper-switcher.scss
+++ b/.config/ags/scss/widgets/wallpaper-switcher.scss
@@ -186,7 +186,7 @@
   .workshop-card {
     // Fixed width, or a long title stretches its column and the grid stops
     // being a grid.
-    min-width: 170px;
+    min-width: 190px;
     padding: 6px;
     border-radius: 10px;
     background: $background-semi-transparent;
@@ -199,9 +199,46 @@
   .workshop-preview {
     border-radius: 8px;
     // A slot that is the same size whether or not the thumbnail has arrived,
-    // so the grid does not reflow as previews come in.
+    // so the grid does not reflow as previews come in. Square, because that
+    // is the shape Steam serves.
     background: $background-secondary;
-    min-height: 84px;
+    min-height: 190px;
+    min-width: 190px;
+  }
+
+  .workshop-filter,
+  .clear-filters,
+  .adult {
+    padding: 2px 10px;
+    border-radius: 6px;
+    font-size: 0.9em;
+  }
+
+  .workshop-filter popover > contents,
+  .workshop-sort popover > contents {
+    background: $background;
+    border: 1px solid $background-secondary;
+    border-radius: 10px;
+    box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.55);
+    padding: 6px;
+  }
+
+  .workshop-filter .popover button,
+  .workshop-sort .popover button {
+    padding: 4px 12px;
+    border-radius: 6px;
+    background: transparent;
+
+    &:hover {
+      background: $background-secondary;
+    }
+
+    // The tag in force in this group.
+    &.selected {
+      background: $secondary;
+      color: $background;
+      font-weight: bold;
+    }
   }
 
   .workshop-title {
@@ -235,8 +272,5 @@
     opacity: 0.7;
   }
 
-  .workshop-filters togglebutton {
-    padding: 2px 10px;
-    border-radius: 6px;
-  }
+
 }

--- a/.config/ags/scss/widgets/wallpaper-switcher.scss
+++ b/.config/ags/scss/widgets/wallpaper-switcher.scss
@@ -333,3 +333,45 @@
     }
   }
 }
+
+// The library's own order control, matching the browser's dropdowns.
+.order-selector {
+  padding: 2px 8px;
+  border-radius: 5px;
+  font-size: 0.85em;
+  min-height: 0;
+  background: $background-secondary;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.3);
+  }
+
+  popover > contents {
+    background: $background;
+    border: 1px solid $background-secondary;
+    border-radius: 10px;
+    box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.55);
+    padding: 6px;
+  }
+
+  .popover {
+    background: transparent;
+
+    button {
+      padding: 4px 12px;
+      border-radius: 6px;
+      background: transparent;
+
+      &:hover {
+        background: $background-secondary;
+      }
+
+      &.selected {
+        background: $secondary;
+        color: $background;
+        font-weight: bold;
+      }
+    }
+  }
+}

--- a/.config/ags/scss/widgets/wallpaper-switcher.scss
+++ b/.config/ags/scss/widgets/wallpaper-switcher.scss
@@ -387,3 +387,17 @@
     }
   }
 }
+
+// Steam mark + magnifier on the Workshop button. The lens rides small and low
+// so the pair reads as one badge rather than two icons in a row.
+.workshop-icon {
+  .steam {
+    font-size: 1.05em;
+  }
+
+  .lens {
+    font-size: 0.72em;
+    opacity: 0.85;
+    margin-top: 4px;
+  }
+}

--- a/.config/ags/scss/widgets/wallpaper-switcher.scss
+++ b/.config/ags/scss/widgets/wallpaper-switcher.scss
@@ -77,3 +77,30 @@
     @include module;
   }
 }
+
+.wallpaper-engine-properties {
+  // The popover draws over the wallpaper grid, so it needs the module
+  // background of its own — otherwise the wallpapers show through the text.
+  @include module;
+
+  min-width: 340px;
+  padding: 10px;
+
+  .title {
+    font-weight: bold;
+  }
+
+  .status {
+    opacity: 0.7;
+  }
+
+  .property {
+    .property-value {
+      min-width: 40px;
+    }
+  }
+
+  .property-combo .popover {
+    @include module;
+  }
+}

--- a/.config/ags/scss/widgets/wallpaper-switcher.scss
+++ b/.config/ags/scss/widgets/wallpaper-switcher.scss
@@ -206,21 +206,24 @@
     min-width: 148px;
   }
 
-  // These are dropdowns, and they have to look like it: as bare labels in a
-  // row they read as a heading strip rather than as controls.
+  // These are dropdowns and have to read as controls, but an outlined box per
+  // filter turns the row into a grid of frames. The chevron carries the
+  // affordance; the surface is just enough tint to separate them from the
+  // panel, and only firms up under the pointer.
   .workshop-filter,
   .workshop-sort,
   .clear-filters,
   .adult {
-    padding: 2px 8px;
-    border-radius: 5px;
+    padding: 2px 9px;
+    border-radius: 999px;
     font-size: 0.82em;
     min-height: 0;
-    background: $background-secondary;
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    border: none;
+    box-shadow: none;
+    background: rgba(255, 255, 255, 0.06);
 
     &:hover {
-      border-color: rgba(255, 255, 255, 0.3);
+      background: rgba(255, 255, 255, 0.14);
     }
   }
 
@@ -336,15 +339,16 @@
 
 // The library's own order control, matching the browser's dropdowns.
 .order-selector {
-  padding: 2px 8px;
-  border-radius: 5px;
+  padding: 2px 9px;
+  border-radius: 999px;
   font-size: 0.85em;
   min-height: 0;
-  background: $background-secondary;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: none;
+  box-shadow: none;
+  background: rgba(255, 255, 255, 0.06);
 
   &:hover {
-    border-color: rgba(255, 255, 255, 0.3);
+    background: rgba(255, 255, 255, 0.14);
   }
 
   popover > contents {

--- a/.config/ags/scss/widgets/wallpaper-switcher.scss
+++ b/.config/ags/scss/widgets/wallpaper-switcher.scss
@@ -158,6 +158,70 @@
     }
   }
 
+  // The Workshop browser: a grid of items this machine does not have yet, so
+  // the cards have to read as browsable rather than as installed wallpapers.
+  .workshop {
+    popover > contents {
+      background: $background;
+      border: 1px solid $background-secondary;
+      border-radius: 12px;
+      box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.55);
+      padding: 10px;
+    }
+  }
+
+  .workshop-browser {
+    .workshop-card {
+      padding: 6px;
+      border-radius: 10px;
+      background: $background-semi-transparent;
+
+      &:hover {
+        background: $background-secondary;
+      }
+    }
+
+    .workshop-preview {
+      border-radius: 8px;
+    }
+
+    .workshop-title {
+      font-weight: bold;
+    }
+
+    .workshop-kind,
+    .workshop-meta {
+      opacity: 0.7;
+      font-size: 0.85em;
+    }
+
+    .workshop-warning {
+      color: $secondary;
+      font-size: 0.8em;
+    }
+
+    .subscribe {
+      padding: 4px 10px;
+      border-radius: 6px;
+
+      // An item already on disk is one click from being shown, so it stops
+      // looking like a download.
+      &.ready {
+        background: $secondary;
+        color: $background;
+      }
+    }
+
+    .workshop-status {
+      opacity: 0.7;
+    }
+
+    .workshop-filters togglebutton {
+      padding: 2px 10px;
+      border-radius: 6px;
+    }
+  }
+
   .color-picker-popover {
     // The wheel supplies its own colour; the popover only has to not tint it.
     background: transparent;

--- a/.config/ags/scss/widgets/wallpaper-switcher.scss
+++ b/.config/ags/scss/widgets/wallpaper-switcher.scss
@@ -158,70 +158,6 @@
     }
   }
 
-  // The Workshop browser: a grid of items this machine does not have yet, so
-  // the cards have to read as browsable rather than as installed wallpapers.
-  .workshop {
-    popover > contents {
-      background: $background;
-      border: 1px solid $background-secondary;
-      border-radius: 12px;
-      box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.55);
-      padding: 10px;
-    }
-  }
-
-  .workshop-browser {
-    .workshop-card {
-      padding: 6px;
-      border-radius: 10px;
-      background: $background-semi-transparent;
-
-      &:hover {
-        background: $background-secondary;
-      }
-    }
-
-    .workshop-preview {
-      border-radius: 8px;
-    }
-
-    .workshop-title {
-      font-weight: bold;
-    }
-
-    .workshop-kind,
-    .workshop-meta {
-      opacity: 0.7;
-      font-size: 0.85em;
-    }
-
-    .workshop-warning {
-      color: $secondary;
-      font-size: 0.8em;
-    }
-
-    .subscribe {
-      padding: 4px 10px;
-      border-radius: 6px;
-
-      // An item already on disk is one click from being shown, so it stops
-      // looking like a download.
-      &.ready {
-        background: $secondary;
-        color: $background;
-      }
-    }
-
-    .workshop-status {
-      opacity: 0.7;
-    }
-
-    .workshop-filters togglebutton {
-      padding: 2px 10px;
-      border-radius: 6px;
-    }
-  }
-
   .color-picker-popover {
     // The wheel supplies its own colour; the popover only has to not tint it.
     background: transparent;
@@ -231,5 +167,76 @@
       border-radius: 6px;
       padding: 4px 8px;
     }
+  }
+}
+
+// The Workshop browser: a grid of items this machine does not have yet, so
+// the cards have to read as browsable rather than as installed wallpapers.
+.workshop {
+  popover > contents {
+    background: $background;
+    border: 1px solid $background-secondary;
+    border-radius: 12px;
+    box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.55);
+    padding: 10px;
+  }
+}
+
+.workshop-browser {
+  .workshop-card {
+    // Fixed width, or a long title stretches its column and the grid stops
+    // being a grid.
+    min-width: 170px;
+    padding: 6px;
+    border-radius: 10px;
+    background: $background-semi-transparent;
+
+    &:hover {
+      background: $background-secondary;
+    }
+  }
+
+  .workshop-preview {
+    border-radius: 8px;
+    // A slot that is the same size whether or not the thumbnail has arrived,
+    // so the grid does not reflow as previews come in.
+    background: $background-secondary;
+    min-height: 84px;
+  }
+
+  .workshop-title {
+    font-weight: bold;
+  }
+
+  .workshop-kind,
+  .workshop-meta {
+    opacity: 0.7;
+    font-size: 0.85em;
+  }
+
+  .workshop-warning {
+    color: $secondary;
+    font-size: 0.8em;
+  }
+
+  .subscribe {
+    padding: 4px 10px;
+    border-radius: 6px;
+
+    // An item already on disk is one click from being shown, so it stops
+    // looking like a download.
+    &.ready {
+      background: $secondary;
+      color: $background;
+    }
+  }
+
+  .workshop-status {
+    opacity: 0.7;
+  }
+
+  .workshop-filters togglebutton {
+    padding: 2px 10px;
+    border-radius: 6px;
   }
 }

--- a/.config/ags/services/kirie.ts
+++ b/.config/ags/services/kirie.ts
@@ -1,6 +1,7 @@
 import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import { execAsync } from "ags/process";
+import { timeout } from "ags/time";
 
 // Client for the kirie wallpaper engine (Wallpaper Engine renderer).
 //
@@ -211,9 +212,35 @@ export function kirieLines(
   });
 }
 
-/** Send one command and resolve with its first reply line. */
+/** Whether a failure is the engine having gone away mid-conversation.
+ *
+ * A restart (or a reload of the wallpaper daemon) closes the socket under any
+ * request already in flight, which surfaces as a broken pipe or a refused
+ * connection — worth one retry, since by then the new engine is usually up. */
+const engineWentAway = (err: unknown) =>
+  /Broken pipe|Connection refused|not reachable|closed/i.test(String(err));
+
+/** Send one command and resolve with its first reply line.
+ *
+ * Retries once when the engine went away: the alternative is showing the user
+ * a Gio error for something that fixes itself in a few hundred milliseconds. */
 export const kirieSend = (cmd: string, timeoutMs?: number): Promise<string> =>
-  kirieLines(cmd, timeoutMs).then((lines) => lines[0] ?? "");
+  kirieLines(cmd, timeoutMs)
+    .catch((err) => {
+      if (!engineWentAway(err)) throw err;
+      return new Promise<string[]>((resolve, reject) => {
+        timeout(400, () => kirieLines(cmd, timeoutMs).then(resolve, reject));
+      });
+    })
+    .then((lines) => lines[0] ?? "")
+    .catch((err) => {
+      // Rephrase the transport's own words: "Error sending data: Broken pipe"
+      // says nothing a user can act on.
+      if (engineWentAway(err)) {
+        throw new Error("the wallpaper engine is not running");
+      }
+      throw err;
+    });
 
 /** Send one command and resolve `true` when the engine accepted it. */
 export const kirieOk = (cmd: string, timeoutMs?: number): Promise<boolean> =>

--- a/.config/ags/services/kirie.ts
+++ b/.config/ags/services/kirie.ts
@@ -334,6 +334,15 @@ export const kirieWorkshopSubscribe = (id: string): Promise<number> =>
 export const kirieWorkshopJob = (job: number): Promise<KirieWorkshopJob> =>
   kirieSend(`workshop job ${job}`).then(workshopJson<KirieWorkshopJob>);
 
+/** `workshop unsubscribe <id>` → the item's state once Steam has accepted.
+ *
+ * Steam deletes the files on its own schedule, so the reply can still carry a
+ * directory: the subscription is what changed. */
+export const kirieWorkshopUnsubscribe = (id: string): Promise<KirieWorkshopItem> =>
+  kirieSend(`workshop unsubscribe ${id}`, WORKSHOP_TIMEOUT).then(
+    (reply) => workshopJson<KirieWorkshopItem[]>(reply)[0],
+  );
+
 /** `workshop state <id>` → subscribed/installed/where, Steam or no Steam. */
 export const kirieWorkshopState = (id: string): Promise<KirieWorkshopItem> =>
   kirieSend(`workshop state ${id}`, WORKSHOP_TIMEOUT).then(

--- a/.config/ags/services/kirie.ts
+++ b/.config/ags/services/kirie.ts
@@ -105,6 +105,21 @@ const kirieBin = (): string | null =>
 /** Whether the engine binary is installed at all. */
 export const kirieInstalled = () => kirieBin() !== null;
 
+/** Whether Wallpaper Engine's shared assets are on this machine.
+ *
+ * Every scene wallpaper needs them, so a machine with kirie but without
+ * Wallpaper Engine has nothing for the engine surface to act on. Asked once
+ * and cached: it is a directory probe, but the panels ask on every rebuild. */
+let weAssets: Promise<boolean> | null = null;
+export const kirieWallpaperEngineInstalled = (): Promise<boolean> => {
+  if (!kirieInstalled()) return Promise.resolve(false);
+  weAssets ??= execAsync([kirieBin() ?? "kirie", "assets", "--json"])
+    .then((json) => Boolean(JSON.parse(json).installed))
+    // Non-zero exit means "not installed", which is an answer, not a failure.
+    .catch(() => false);
+  return weAssets;
+};
+
 /** Run the engine CLI and parse its JSON output. */
 const kirieJson = <T,>(args: string[]): Promise<T> =>
   execAsync([kirieBin() ?? "kirie", ...args]).then((json) => JSON.parse(json));

--- a/.config/ags/services/kirie.ts
+++ b/.config/ags/services/kirie.ts
@@ -41,6 +41,43 @@ export interface KirieProperty {
   options?: { label: string; value: any }[];
 }
 
+/** One Workshop search result (`workshop search`, docs/compat-socket.md §13).
+ *
+ * Shares `KirieItem`'s keys so a picker can render browsable and installed
+ * wallpapers from one code path; `dir` is null until the files arrive. */
+export interface KirieWorkshopItem extends KirieItem {
+  dir: string;
+  subscribed: boolean;
+  installed: boolean;
+  size: number;
+  votes_up: number;
+  votes_down: number;
+  score: number;
+  updated: number;
+  tags: string[];
+}
+
+/** What to ask the Workshop for. */
+export interface KirieWorkshopQuery {
+  text?: string;
+  tags?: string[];
+  excludeTags?: string[];
+  sort?: "popular" | "trend" | "recent" | "rated";
+  days?: number;
+  page?: number;
+  limit?: number;
+}
+
+/** A subscription in flight (`workshop job <n>`). */
+export interface KirieWorkshopJob {
+  job: number;
+  id: string;
+  state: "subscribing" | "downloading" | "installed" | "error";
+  bytes: number;
+  dir: string | null;
+  error: string | null;
+}
+
 /** A GPU kirie can be pinned to, as reported by `kirie gpus --json`. */
 export interface KirieGpu {
   value: string;
@@ -245,3 +282,69 @@ export const kirieGpus = (): Promise<KirieGpu[]> =>
  * report too. */
 export const kirieCheck = (): Promise<string> =>
   execAsync([kirieBin() ?? "kirie", "check"]);
+
+// --- Workshop (docs/compat-socket.md §13) -----------------------------------
+//
+// These are the only calls here that leave the machine: the engine hands the
+// request to a short-lived Steam helper, which talks to the local Steam
+// client. They take seconds rather than milliseconds, so they set their own
+// timeouts — the 2s default of the rest of this file would fail every search.
+
+/** How long to allow a Workshop query. The engine's own cap is 30s. */
+const WORKSHOP_TIMEOUT = 30000;
+
+/** Parse a Workshop reply, turning the engine's `{"error":…}` into a rejection. */
+const workshopJson = <T,>(reply: string): T => {
+  const value = JSON.parse(reply);
+  if (value && !Array.isArray(value) && typeof value.error === "string") {
+    throw new Error(value.error);
+  }
+  return value as T;
+};
+
+/** `workshop search` — browse the Workshop, installed or not.
+ *
+ * `text` goes last in the wire format: a search phrase has spaces in it and
+ * the engine reads it as the rest of the line. */
+export const kirieWorkshopSearch = (
+  query: KirieWorkshopQuery = {},
+): Promise<KirieWorkshopItem[]> => {
+  const args: string[] = [];
+  for (const tag of query.tags ?? []) args.push(`tag=${tag}`);
+  for (const tag of query.excludeTags ?? []) args.push(`nottag=${tag}`);
+  if (query.sort) args.push(`sort=${query.sort}`);
+  if (query.days) args.push(`days=${query.days}`);
+  if (query.page) args.push(`page=${query.page}`);
+  if (query.limit) args.push(`limit=${query.limit}`);
+  const text = query.text?.trim();
+  if (text) args.push(`text=${text}`);
+
+  return kirieSend(`workshop search ${args.join(" ")}`, WORKSHOP_TIMEOUT).then(
+    workshopJson<KirieWorkshopItem[]>,
+  );
+};
+
+/** `workshop subscribe <id>` → the job number following the download. */
+export const kirieWorkshopSubscribe = (id: string): Promise<number> =>
+  kirieSend(`workshop subscribe ${id}`, WORKSHOP_TIMEOUT).then(
+    (reply) => workshopJson<{ job: number }>(reply).job,
+  );
+
+/** `workshop job <n>` → how that subscription is going. */
+export const kirieWorkshopJob = (job: number): Promise<KirieWorkshopJob> =>
+  kirieSend(`workshop job ${job}`).then(workshopJson<KirieWorkshopJob>);
+
+/** `workshop state <id>` → subscribed/installed/where, Steam or no Steam. */
+export const kirieWorkshopState = (id: string): Promise<KirieWorkshopItem> =>
+  kirieSend(`workshop state ${id}`, WORKSHOP_TIMEOUT).then(
+    (reply) => workshopJson<KirieWorkshopItem[]>(reply)[0],
+  );
+
+/** Whether this engine speaks the Workshop verbs at all.
+ *
+ * An engine from before they existed answers `unknown command`, and the
+ * browser has to say so rather than look broken. */
+export const kirieWorkshopSupported = (): Promise<boolean> =>
+  kirieSend("workshop job 0")
+    .then((reply) => !reply.startsWith("unknown"))
+    .catch(() => false);

--- a/.config/ags/services/kirie.ts
+++ b/.config/ags/services/kirie.ts
@@ -212,11 +212,8 @@ export function kirieLines(
   });
 }
 
-/** Whether a failure is the engine having gone away mid-conversation.
- *
- * A restart (or a reload of the wallpaper daemon) closes the socket under any
- * request already in flight, which surfaces as a broken pipe or a refused
- * connection — worth one retry, since by then the new engine is usually up. */
+/** Whether a failure is the engine having gone away mid-conversation: a
+ * restart closes the socket under any request in flight. Worth one retry. */
 const engineWentAway = (err: unknown) =>
   /Broken pipe|Connection refused|not reachable|closed/i.test(String(err));
 
@@ -312,10 +309,8 @@ export const kirieCheck = (): Promise<string> =>
 
 // --- Workshop (docs/compat-socket.md §13) -----------------------------------
 //
-// These are the only calls here that leave the machine: the engine hands the
-// request to a short-lived Steam helper, which talks to the local Steam
-// client. They take seconds rather than milliseconds, so they set their own
-// timeouts — the 2s default of the rest of this file would fail every search.
+// The only calls here that leave the machine, so they take seconds and set
+// their own timeout; this file's 2s default would fail every search.
 
 /** How long to allow a Workshop query. The engine's own cap is 30s. */
 const WORKSHOP_TIMEOUT = 30000;

--- a/.config/ags/services/kirie.ts
+++ b/.config/ags/services/kirie.ts
@@ -1,0 +1,247 @@
+import Gio from "gi://Gio";
+import GLib from "gi://GLib";
+import { execAsync } from "ags/process";
+
+// Client for the kirie wallpaper engine (Wallpaper Engine renderer).
+//
+// kirie owns a control socket and answers questions about itself in JSON, so
+// nothing here re-derives what it already knows: the socket carries the live
+// state, the CLI answers when no engine is running. Both are spoken directly
+// from AGS — the socket over Gio, the CLI over execAsync — so there is no
+// helper daemon and no shell in the interactive path.
+//
+// Wire contract (kirie-ipc): connect, write ONE line, read the reply, the
+// engine closes. Each call is therefore self-contained and there is nothing to
+// reconnect after an AGS restart.
+
+export const kirieSocket = `${GLib.getenv("XDG_RUNTIME_DIR") ?? "/tmp"}/lwe.sock`;
+
+/** An installed Wallpaper Engine item, as reported by `kirie list --json`. */
+export interface KirieItem {
+  id: string;
+  title: string;
+  type: string;
+  dir: string;
+  preview: string | null;
+  renderable: boolean;
+  reason: string | null;
+}
+
+/** One entry of a wallpaper's property schema (project.json user properties,
+ * with the live overrides already folded into `value` by the engine). */
+export interface KirieProperty {
+  key: string;
+  type: "bool" | "slider" | "color" | "combo" | "textinput" | "file" | "directory";
+  text: string;
+  value: any;
+  min?: number;
+  max?: number;
+  step?: number;
+  order?: number;
+  options?: { label: string; value: any }[];
+}
+
+/** A GPU kirie can be pinned to, as reported by `kirie gpus --json`. */
+export interface KirieGpu {
+  value: string;
+  label: string;
+  kind: string;
+  icd: string | null;
+}
+
+/** Parsed `status` reply: the global speed plus the background per screen. */
+export interface KirieStatus {
+  speed: number;
+  screens: { screen: string; bg: string }[];
+}
+
+// The engine is installed per user, and the session PATH does not always carry
+// ~/.local/bin when the compositor starts the shell.
+const fallbackBin = `${GLib.get_home_dir()}/.local/bin/kirie`;
+const kirieBin = (): string | null =>
+  GLib.find_program_in_path("kirie") ??
+  (GLib.file_test(fallbackBin, GLib.FileTest.IS_EXECUTABLE)
+    ? fallbackBin
+    : null);
+
+/** Whether the engine binary is installed at all. */
+export const kirieInstalled = () => kirieBin() !== null;
+
+/** Run the engine CLI and parse its JSON output. */
+const kirieJson = <T,>(args: string[]): Promise<T> =>
+  execAsync([kirieBin() ?? "kirie", ...args]).then((json) => JSON.parse(json));
+
+/**
+ * Send one command and collect every reply line until the engine closes.
+ * Rejects when the socket is missing (engine down), on a timeout, or when the
+ * connection closes without a reply — callers surface that as a notification.
+ *
+ * `bg` waits longer: the engine replies only once the wallpaper is actually
+ * applied, and a heavy scene takes seconds to build.
+ */
+export function kirieLines(
+  cmd: string,
+  timeoutMs = cmd.startsWith("bg ") ? 15000 : 2000,
+): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const cancellable = new Gio.Cancellable();
+    let timer: number | null = GLib.timeout_add(
+      GLib.PRIORITY_DEFAULT,
+      timeoutMs,
+      () => {
+        timer = null;
+        cancellable.cancel();
+        reject(new Error(`kirie: "${cmd}" timed out after ${timeoutMs}ms`));
+        return GLib.SOURCE_REMOVE;
+      },
+    );
+    const settle = (fn: () => void) => {
+      if (timer !== null) {
+        GLib.source_remove(timer);
+        timer = null;
+      }
+      fn();
+    };
+
+    const client = new Gio.SocketClient();
+    client.connect_async(
+      Gio.UnixSocketAddress.new(kirieSocket),
+      cancellable,
+      (_client, res) => {
+        let conn: Gio.SocketConnection;
+        try {
+          conn = client.connect_finish(res);
+        } catch (e) {
+          settle(() => reject(new Error(`kirie: engine not reachable (${e})`)));
+          return;
+        }
+        const close = () => {
+          try {
+            conn.close(null);
+          } catch {}
+        };
+
+        conn.get_output_stream().write_bytes_async(
+          new GLib.Bytes(new TextEncoder().encode(`${cmd}\n`)),
+          GLib.PRIORITY_DEFAULT,
+          cancellable,
+          (stream, wres) => {
+            try {
+              (stream as Gio.OutputStream).write_bytes_finish(wres);
+            } catch (e) {
+              close();
+              settle(() => reject(new Error(`kirie: write failed (${e})`)));
+              return;
+            }
+
+            const input = new Gio.DataInputStream({
+              base_stream: conn.get_input_stream(),
+              close_base_stream: false,
+            });
+            const lines: string[] = [];
+            const readNext = () =>
+              input.read_line_async(
+                GLib.PRIORITY_DEFAULT,
+                cancellable,
+                (_s, rres) => {
+                  let line: string | null = null;
+                  try {
+                    [line] = input.read_line_finish_utf8(rres);
+                  } catch (e) {
+                    close();
+                    settle(() => reject(new Error(`kirie: read failed (${e})`)));
+                    return;
+                  }
+                  if (line !== null) {
+                    lines.push(line.trim());
+                    readNext();
+                    return;
+                  }
+                  // EOF: the engine closed after its reply, as the protocol says.
+                  close();
+                  settle(() =>
+                    lines.length === 0
+                      ? reject(new Error("kirie: closed without a reply"))
+                      : resolve(lines),
+                  );
+                },
+              );
+            readNext();
+          },
+        );
+      },
+    );
+  });
+}
+
+/** Send one command and resolve with its first reply line. */
+export const kirieSend = (cmd: string, timeoutMs?: number): Promise<string> =>
+  kirieLines(cmd, timeoutMs).then((lines) => lines[0] ?? "");
+
+/** Send one command and resolve `true` when the engine accepted it. */
+export const kirieOk = (cmd: string, timeoutMs?: number): Promise<boolean> =>
+  kirieSend(cmd, timeoutMs)
+    .then((r) => r !== "" && !r.startsWith("error") && !r.startsWith("unknown"))
+    .catch(() => false);
+
+/** Whether an engine is up and answering. */
+export const kirieAlive = (): Promise<boolean> =>
+  kirieSend("ping")
+    .then((r) => r === "pong")
+    .catch(() => false);
+
+/** `status` → the speed and the background recorded for every screen. */
+export const kirieStatus = (): Promise<KirieStatus> =>
+  kirieLines("status").then((lines) => {
+    const status: KirieStatus = { speed: 1, screens: [] };
+    for (const line of lines) {
+      if (line.startsWith("speed=")) {
+        status.speed = parseFloat(line.slice(6)) || 1;
+      } else if (line.startsWith("screen=")) {
+        // `screen=<name> bg=<path>` — the path may contain spaces.
+        const bgAt = line.indexOf(" bg=");
+        if (bgAt > 7)
+          status.screens.push({
+            screen: line.slice(7, bgAt),
+            bg: line.slice(bgAt + 4),
+          });
+      }
+    }
+    return status;
+  });
+
+/** The item directory rendered on `monitor`, or "" when nothing is. */
+export const kirieCurrentItem = (monitor: string): Promise<string> =>
+  kirieStatus()
+    .then((s) => s.screens.find((sc) => sc.screen === monitor)?.bg ?? "")
+    .catch(() => "");
+
+const byOrder = (a: KirieProperty, b: KirieProperty) =>
+  (a.order ?? 0) - (b.order ?? 0);
+
+/** `getproperties <monitor>` → the live schema, overrides folded in. */
+export const kirieProperties = (monitor: string): Promise<KirieProperty[]> =>
+  kirieSend(`getproperties ${monitor}`).then((json) =>
+    (JSON.parse(json) as KirieProperty[]).sort(byOrder),
+  );
+
+/** The schema of an item that is not being rendered — read straight off its
+ * `project.json`, so the properties UI works with the engine down. */
+export const kirieItemProperties = (item: string): Promise<KirieProperty[]> =>
+  kirieJson<KirieProperty[]>(["--list-properties-json", item]).then((schema) =>
+    schema.sort(byOrder),
+  );
+
+/** Every Wallpaper Engine item installed on this machine. */
+export const kirieList = (): Promise<KirieItem[]> =>
+  kirieJson<KirieItem[]>(["list", "--json"]);
+
+/** The GPUs kirie can be pinned to (first entry is "auto"). */
+export const kirieGpus = (): Promise<KirieGpu[]> =>
+  kirieJson<KirieGpu[]>(["gpus", "--json"]);
+
+/** `kirie check` — the engine's own report on what it needs here. It exits
+ * non-zero when something required is missing, so the failure carries the
+ * report too. */
+export const kirieCheck = (): Promise<string> =>
+  execAsync([kirieBin() ?? "kirie", "check"]);

--- a/.config/ags/widgets/ColorPicker.tsx
+++ b/.config/ags/widgets/ColorPicker.tsx
@@ -1,24 +1,16 @@
 import { Gtk } from "ags/gtk4";
 import Gdk from "gi://Gdk";
 
-// A small colour picker that lives inside the panel.
-//
-// GTK's own `Gtk.ColorDialog` opens a full dialog window: under a layer-shell
-// shell it has no parent to sit on, so the compositor drops it in the corner
-// at whatever size it asks for — a palette grid taking a third of the screen
-// to set one wallpaper colour. This is the same job as a popover on the swatch
-// itself: an HSV wheel, a value/saturation square inside it, and a hex field.
+// An HSV wheel in a popover on the swatch. Gtk.ColorDialog opens a window,
+// and under layer-shell it has no parent to sit on — the compositor drops a
+// palette grid in the screen corner to set one wallpaper colour.
 
 /// Wheel side in pixels, and how thick the hue ring is.
 const SIZE = 176;
 const RING = 14;
 
-/// Cells across the saturation/value square.
-///
-/// It is painted as a grid rather than with cairo gradients: two overlaid
-/// gradients need a mesh or per-pixel surface to look right, while 26×26 flat
-/// cells are exact, redraw in well under a frame, and never depend on which
-/// cairo bindings gjs happens to expose.
+/// Cells across the saturation/value square. A grid rather than gradients:
+/// two overlaid cairo gradients need a mesh to look right.
 const CELLS = 26;
 
 /// HSV (each 0..1) to RGB (each 0..1).

--- a/.config/ags/widgets/ColorPicker.tsx
+++ b/.config/ags/widgets/ColorPicker.tsx
@@ -1,0 +1,300 @@
+import { Gtk } from "ags/gtk4";
+import Gdk from "gi://Gdk";
+
+// A small colour picker that lives inside the panel.
+//
+// GTK's own `Gtk.ColorDialog` opens a full dialog window: under a layer-shell
+// shell it has no parent to sit on, so the compositor drops it in the corner
+// at whatever size it asks for — a palette grid taking a third of the screen
+// to set one wallpaper colour. This is the same job as a popover on the swatch
+// itself: an HSV wheel, a value/saturation square inside it, and a hex field.
+
+/// Wheel side in pixels, and how thick the hue ring is.
+const SIZE = 176;
+const RING = 14;
+
+/// Cells across the saturation/value square.
+///
+/// It is painted as a grid rather than with cairo gradients: two overlaid
+/// gradients need a mesh or per-pixel surface to look right, while 26×26 flat
+/// cells are exact, redraw in well under a frame, and never depend on which
+/// cairo bindings gjs happens to expose.
+const CELLS = 26;
+
+/// HSV (each 0..1) to RGB (each 0..1).
+const hsvToRgb = (h: number, s: number, v: number): [number, number, number] => {
+  const i = Math.floor(h * 6);
+  const f = h * 6 - i;
+  const p = v * (1 - s);
+  const q = v * (1 - f * s);
+  const t = v * (1 - (1 - f) * s);
+  switch (i % 6) {
+    case 0:
+      return [v, t, p];
+    case 1:
+      return [q, v, p];
+    case 2:
+      return [p, v, t];
+    case 3:
+      return [p, q, v];
+    case 4:
+      return [t, p, v];
+    default:
+      return [v, p, q];
+  }
+};
+
+/// RGB (each 0..1) to HSV (each 0..1).
+const rgbToHsv = (r: number, g: number, b: number): [number, number, number] => {
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+  let h = 0;
+  if (d !== 0) {
+    if (max === r) h = ((g - b) / d) % 6;
+    else if (max === g) h = (b - r) / d + 2;
+    else h = (r - g) / d + 4;
+    h /= 6;
+    if (h < 0) h += 1;
+  }
+  return [h, max === 0 ? 0 : d / max, max];
+};
+
+const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+
+const toHex = (r: number, g: number, b: number) =>
+  "#" +
+  [r, g, b]
+    .map((c) =>
+      Math.round(clamp01(c) * 255)
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("");
+
+/// Parse `#rgb`, `#rrggbb` or a bare hex triple; `null` when it is not one.
+const fromHex = (text: string): [number, number, number] | null => {
+  const hex = text.trim().replace(/^#/, "");
+  const full =
+    hex.length === 3
+      ? hex
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : hex;
+  if (!/^[0-9a-fA-F]{6}$/.test(full)) return null;
+  return [
+    parseInt(full.slice(0, 2), 16) / 255,
+    parseInt(full.slice(2, 4), 16) / 255,
+    parseInt(full.slice(4, 6), 16) / 255,
+  ];
+};
+
+export default function ColorPicker({
+  rgba,
+  onPicked,
+}: {
+  /// The colour to open on.
+  rgba: Gdk.RGBA;
+  /// Called on every change, so the wallpaper follows the drag live.
+  onPicked: (rgba: Gdk.RGBA) => void;
+}) {
+  let [h, s, v] = rgbToHsv(rgba.red, rgba.green, rgba.blue);
+
+  // Painted rather than styled. `css` on a widget built outside JSX is gnim's
+  // property, not GTK's, and the class list it works through is the same one
+  // this code sets — so the swatch came out empty. A drawing area owes nothing
+  // to the stylesheet and always shows the colour it is given.
+  const swatch = new Gtk.DrawingArea({
+    widthRequest: 34,
+    heightRequest: 20,
+    cssClasses: ["color-swatch"],
+  });
+  const hexEntry = new Gtk.Entry({
+    maxWidthChars: 9,
+    widthChars: 9,
+    xalign: 0.5,
+  });
+
+  const wheel = new Gtk.DrawingArea({
+    widthRequest: SIZE,
+    heightRequest: SIZE,
+    cssClasses: ["color-wheel"],
+  });
+
+  /// Push the current HSV everywhere: the wheel, the swatch, the hex field and
+  /// the caller.
+  const publish = (notify = true) => {
+    const [r, g, b] = hsvToRgb(h, s, v);
+    const hex = toHex(r, g, b);
+    if (hexEntry.text !== hex) hexEntry.text = hex;
+    swatch.queue_draw();
+    wheel.queue_draw();
+    if (!notify) return;
+    const out = new Gdk.RGBA();
+    out.red = r;
+    out.green = g;
+    out.blue = b;
+    out.alpha = 1;
+    onPicked(out);
+  };
+
+  wheel.set_draw_func((_area, cr, width, height) => {
+    const cx = width / 2;
+    const cy = height / 2;
+    const outer = Math.min(width, height) / 2 - 1;
+    const inner = outer - RING;
+
+    // Hue ring, in wedges. A stroked arc per wedge, slightly overlapping so no
+    // seams show between them.
+    cr.setLineWidth(RING);
+    for (let deg = 0; deg < 360; deg += 2) {
+      const a0 = (deg * Math.PI) / 180;
+      const a1 = ((deg + 2.6) * Math.PI) / 180;
+      const [r, g, b] = hsvToRgb(deg / 360, 1, 1);
+      cr.setSourceRGBA(r, g, b, 1);
+      cr.arc(cx, cy, (outer + inner) / 2, a0, a1);
+      cr.stroke();
+    }
+
+    // Saturation/value square, inscribed in the ring.
+    const side = inner * Math.SQRT2 - 4;
+    const x0 = cx - side / 2;
+    const y0 = cy - side / 2;
+    const step = side / CELLS;
+    for (let ix = 0; ix < CELLS; ix += 1) {
+      for (let iy = 0; iy < CELLS; iy += 1) {
+        const [r, g, b] = hsvToRgb(
+          h,
+          (ix + 0.5) / CELLS,
+          1 - (iy + 0.5) / CELLS,
+        );
+        cr.setSourceRGBA(r, g, b, 1);
+        // Half a pixel of overlap, again to avoid hairlines between cells.
+        cr.rectangle(x0 + ix * step, y0 + iy * step, step + 0.5, step + 0.5);
+        cr.fill();
+      }
+    }
+
+    // Hue marker.
+    const angle = h * 2 * Math.PI;
+    const mx = cx + Math.cos(angle) * ((outer + inner) / 2);
+    const my = cy + Math.sin(angle) * ((outer + inner) / 2);
+    cr.setLineWidth(2);
+    cr.setSourceRGBA(0, 0, 0, 0.7);
+    cr.arc(mx, my, RING / 2 - 1, 0, 2 * Math.PI);
+    cr.stroke();
+    cr.setSourceRGBA(1, 1, 1, 0.95);
+    cr.arc(mx, my, RING / 2 - 2.5, 0, 2 * Math.PI);
+    cr.stroke();
+
+    // Saturation/value marker, outlined in both black and white so it stays
+    // visible over every part of the square.
+    const px = x0 + s * side;
+    const py = y0 + (1 - v) * side;
+    cr.setSourceRGBA(0, 0, 0, 0.8);
+    cr.arc(px, py, 6, 0, 2 * Math.PI);
+    cr.stroke();
+    cr.setSourceRGBA(1, 1, 1, 0.95);
+    cr.arc(px, py, 4.5, 0, 2 * Math.PI);
+    cr.stroke();
+  });
+
+  swatch.set_draw_func((_area, cr, width, height) => {
+    const [r, g, b] = hsvToRgb(h, s, v);
+    const radius = 4;
+    // A rounded rect, so the preview matches the pill shapes around it.
+    cr.newPath();
+    cr.arc(width - radius, radius, radius, -Math.PI / 2, 0);
+    cr.arc(width - radius, height - radius, radius, 0, Math.PI / 2);
+    cr.arc(radius, height - radius, radius, Math.PI / 2, Math.PI);
+    cr.arc(radius, radius, radius, Math.PI, (3 * Math.PI) / 2);
+    cr.closePath();
+    cr.setSourceRGBA(r, g, b, 1);
+    cr.fillPreserve();
+    cr.setLineWidth(1);
+    cr.setSourceRGBA(1, 1, 1, 0.25);
+    cr.stroke();
+  });
+
+  /// Which control a press landed on. Decided once per gesture, so a drag that
+  /// starts on the ring keeps setting the hue even when it leaves it.
+  let dragging: "ring" | "square" | null = null;
+
+  const pick = (x: number, y: number) => {
+    const cx = SIZE / 2;
+    const cy = SIZE / 2;
+    const outer = SIZE / 2 - 1;
+    const inner = outer - RING;
+    const dx = x - cx;
+    const dy = y - cy;
+    const dist = Math.hypot(dx, dy);
+
+    if (dragging === null) {
+      dragging = dist > inner - 2 ? "ring" : "square";
+    }
+
+    if (dragging === "ring") {
+      let angle = Math.atan2(dy, dx);
+      if (angle < 0) angle += 2 * Math.PI;
+      h = angle / (2 * Math.PI);
+    } else {
+      const side = inner * Math.SQRT2 - 4;
+      const x0 = cx - side / 2;
+      const y0 = cy - side / 2;
+      s = clamp01((x - x0) / side);
+      v = clamp01(1 - (y - y0) / side);
+    }
+    publish();
+  };
+
+  const click = new Gtk.GestureClick();
+  click.connect("pressed", (_g, _n, x, y) => {
+    dragging = null;
+    pick(x, y);
+  });
+  click.connect("released", () => {
+    dragging = null;
+  });
+  wheel.add_controller(click);
+
+  const drag = new Gtk.GestureDrag();
+  drag.connect("drag-update", (gesture, ox, oy) => {
+    const [, sx, sy] = gesture.get_start_point();
+    pick(sx + ox, sy + oy);
+  });
+  drag.connect("drag-end", () => {
+    dragging = null;
+  });
+  wheel.add_controller(drag);
+
+  hexEntry.connect("activate", () => {
+    const parsed = fromHex(hexEntry.text);
+    if (!parsed) {
+      // Not a colour: put the current one back rather than leave a typo that
+      // looks like it was accepted.
+      publish(false);
+      return;
+    }
+    [h, s, v] = rgbToHsv(...parsed);
+    publish();
+  });
+
+  publish(false);
+
+  return (
+    <menubutton class="color-picker" halign={Gtk.Align.END}>
+      {swatch}
+      {/* Same reason as the combo list: opening downwards would cover the
+          colours it is being matched against. */}
+      <popover class="color-picker-popover" position={Gtk.PositionType.LEFT}>
+        <box orientation={Gtk.Orientation.VERTICAL} spacing={8}>
+          {wheel}
+          <box spacing={6} halign={Gtk.Align.CENTER}>
+            {hexEntry}
+          </box>
+        </box>
+      </popover>
+    </menubutton>
+  );
+}

--- a/.config/ags/widgets/WallpaperEngineProperties.tsx
+++ b/.config/ags/widgets/WallpaperEngineProperties.tsx
@@ -44,8 +44,31 @@ const wireValue = (value: any): string => String(value);
 
 /** Wallpapers that were translated carry a localization key where their label
  * should be ("ui_browse_properties_scheme_color"); show something readable. */
+/// Turn a wallpaper author's label into one line of readable text.
+///
+/// A `project.json` label is whatever its author typed, and plenty of them are
+/// HTML — banners, credit links, whole `<img>` tags. GTK renders that verbatim
+/// on one enormous line, so the panel ended up wider than the screen showing
+/// markup nobody can read. Tags come out, entities are decoded, whitespace
+/// collapses, and a label that was *only* markup falls back to its key.
+function plainText(raw: string): string {
+  const stripped = raw
+    // Anything inside a tag goes; an <img> or <a> carries no text of its own.
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+  // A bare URL left behind by a stripped link is not a label either.
+  return /^https?:\/\/\S*$/.test(stripped) ? "" : stripped;
+}
+
 function propertyLabel(property: KirieProperty): string {
-  const text = property.text || property.key;
+  const text = plainText(property.text || "") || property.key;
   if (!text.startsWith("ui_")) return text;
 
   return text
@@ -127,7 +150,12 @@ export default function WallpaperEngineProperties({
         class="property-name"
         hexpand
         xalign={0}
+        // Wrapped and capped: a long label is the author's business, but a row
+        // that sets the panel's width is ours.
+        wrap={true}
+        maxWidthChars={28}
         label={propertyLabel(property)}
+        tooltipText={propertyLabel(property)}
       />
     );
 
@@ -283,7 +311,16 @@ export default function WallpaperEngineProperties({
       $={load}
     >
       <box spacing={10}>
-        <label class="title" hexpand xalign={0} label={item.title} />
+        {/* Item titles carry the same author-written markup the labels do. */}
+        <label
+          class="title"
+          hexpand
+          xalign={0}
+          wrap={true}
+          maxWidthChars={30}
+          label={plainText(item.title) || item.id}
+          tooltipText={plainText(item.title) || item.id}
+        />
         <button
           class="reset"
           label="󰑐"

--- a/.config/ags/widgets/WallpaperEngineProperties.tsx
+++ b/.config/ags/widgets/WallpaperEngineProperties.tsx
@@ -1,0 +1,308 @@
+import { createState, For, With } from "ags";
+import { Gtk } from "ags/gtk4";
+import Gdk from "gi://Gdk";
+import GLib from "gi://GLib";
+import { execAsync } from "ags/process";
+import { timeout } from "ags/time";
+import { notify } from "../utils/notification";
+import { readJSONFile, writeJSONFile } from "../utils/json";
+import {
+  KirieItem,
+  KirieProperty,
+  kirieCurrentItem,
+  kirieItemProperties,
+  kirieOk,
+  kirieProperties,
+} from "../services/kirie";
+
+// Every Wallpaper Engine wallpaper ships its own settings — bloom, colour
+// schemes, speeds, the odd file picker — and kirie serves that schema as JSON.
+// The controls below are generated from it, so a wallpaper nobody has seen
+// before is editable without a line of code for it.
+//
+// The engine keeps live overrides in memory only, so what is edited here is
+// also written to a per-item file that the wallpaper daemon stages back in the
+// next time the item is loaded.
+
+const overridePath = (id: string) =>
+  `${GLib.get_home_dir()}/.config/ags/cache/wallpaper-engine/${id}.json`;
+
+const readOverrides = (id: string): Record<string, any> =>
+  readJSONFile(overridePath(id), {});
+
+function saveOverride(id: string, key: string, value: any) {
+  const overrides = readOverrides(id);
+  overrides[key] = value;
+  writeJSONFile(overridePath(id), overrides);
+}
+
+/** The wire form of a property value: the engine reads booleans as
+ * `true`/`false`, sliders as decimals and everything else verbatim, which is
+ * what String() already produces for each of them. */
+const wireValue = (value: any): string => String(value);
+
+/** Wallpapers that were translated carry a localization key where their label
+ * should be ("ui_browse_properties_scheme_color"); show something readable. */
+function propertyLabel(property: KirieProperty): string {
+  const text = property.text || property.key;
+  if (!text.startsWith("ui_")) return text;
+
+  return text
+    .replace(/^ui_(browse_)?(properties_)?/, "")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+const rgbaToTriple = (rgba: Gdk.RGBA) =>
+  `${rgba.red.toFixed(6)} ${rgba.green.toFixed(6)} ${rgba.blue.toFixed(6)}`;
+
+function tripleToRgba(triple: any): Gdk.RGBA {
+  const [r, g, b] = String(triple ?? "0 0 0")
+    .trim()
+    .split(/\s+/)
+    .map((n) => parseFloat(n) || 0);
+  const rgba = new Gdk.RGBA();
+  rgba.red = r ?? 0;
+  rgba.green = g ?? 0;
+  rgba.blue = b ?? 0;
+  rgba.alpha = 1;
+  return rgba;
+}
+
+export default function WallpaperEngineProperties({
+  monitor,
+  item,
+}: {
+  monitor: string;
+  item: KirieItem;
+}) {
+  const [properties, setProperties] = createState<KirieProperty[]>([]);
+  const [status, setStatus] = createState("Loading…");
+  // Only the wallpaper actually on screen can be changed live; the rest are
+  // edited for the next time they are applied.
+  let live = false;
+
+  async function load() {
+    try {
+      live = (await kirieCurrentItem(monitor)) === item.dir;
+      const schema = live
+        ? await kirieProperties(monitor)
+        : await kirieItemProperties(item.dir);
+      setProperties(schema);
+      setStatus(
+        schema.length === 0
+          ? "This wallpaper has no settings."
+          : live
+            ? ""
+            : "Not on this monitor — changes apply when it is.",
+      );
+    } catch (err) {
+      setProperties([]);
+      setStatus(String(err));
+    }
+  }
+
+  function apply(property: KirieProperty, value: any) {
+    saveOverride(item.id, property.key, value);
+    if (live) kirieOk(`property ${monitor} ${property.key} ${wireValue(value)}`);
+  }
+
+  function reset() {
+    writeJSONFile(overridePath(item.id), {});
+    if (live)
+      for (const property of properties.peek())
+        kirieOk(
+          `property ${monitor} ${property.key} ${wireValue(property.value)}`,
+        );
+    load();
+    notify({ summary: item.title, body: "Wallpaper settings reset." });
+  }
+
+  const Property = (property: KirieProperty) => {
+    const saved = readOverrides(item.id)[property.key];
+    const value = saved !== undefined ? saved : property.value;
+    const title = (
+      <label
+        class="property-name"
+        hexpand
+        xalign={0}
+        label={propertyLabel(property)}
+      />
+    );
+
+    switch (property.type) {
+      case "bool":
+        return (
+          <box class="property" spacing={5}>
+            {title}
+            <switch
+              halign={Gtk.Align.END}
+              active={value === true || value === "true"}
+              onNotifyActive={(self) => apply(property, self.active)}
+            />
+          </box>
+        );
+
+      case "slider": {
+        const readout = (
+          <label class="property-value" label={Number(value).toFixed(2)} />
+        ) as Gtk.Label;
+        let pending: any = null;
+
+        return (
+          <box class="property" spacing={5}>
+            {title}
+            <box halign={Gtk.Align.END} spacing={5}>
+              <slider
+                class="slider"
+                widthRequest={140}
+                drawValue={false}
+                min={property.min ?? 0}
+                max={property.max ?? 1}
+                step={property.step ?? 0.01}
+                value={Number(value) || 0}
+                onValueChanged={(self) => {
+                  const next = parseFloat(self.get_value().toFixed(3));
+                  readout.label = next.toFixed(2);
+                  // The engine rebuilds the scene per change; coalesce a drag
+                  // into one write.
+                  pending?.cancel?.();
+                  pending = timeout(150, () => apply(property, next));
+                }}
+              />
+              {readout}
+            </box>
+          </box>
+        );
+      }
+
+      case "combo":
+        return (
+          <box class="property" spacing={5}>
+            {title}
+            <menubutton class="property-combo" halign={Gtk.Align.END}>
+              <label
+                label={
+                  property.options?.find(
+                    (option) => String(option.value) === String(value),
+                  )?.label ?? String(value)
+                }
+              />
+              <popover>
+                <box orientation={Gtk.Orientation.VERTICAL} class="popover">
+                  {(property.options ?? []).map((option) => (
+                    <button
+                      label={option.label}
+                      onClicked={(self) => {
+                        apply(property, option.value);
+                        (
+                          self.get_ancestor(Gtk.Popover) as Gtk.Popover
+                        )?.popdown();
+                        load();
+                      }}
+                    />
+                  ))}
+                </box>
+              </popover>
+            </menubutton>
+          </box>
+        );
+
+      case "color":
+        return (
+          <box class="property" spacing={5}>
+            {title}
+            <Gtk.ColorDialogButton
+              halign={Gtk.Align.END}
+              dialog={new Gtk.ColorDialog({ withAlpha: false })}
+              rgba={tripleToRgba(value)}
+              $={(self: Gtk.ColorDialogButton) =>
+                self.connect("notify::rgba", () =>
+                  apply(property, rgbaToTriple(self.get_rgba())),
+                )
+              }
+            />
+          </box>
+        );
+
+      case "file":
+      case "directory":
+        return (
+          <box class="property" spacing={5}>
+            {title}
+            <button
+              class="property-file"
+              halign={Gtk.Align.END}
+              tooltipText={String(value || "")}
+              label={String(value || "Choose…")
+                .split("/")
+                .pop()
+                ?.slice(0, 20)}
+              onClicked={(self) => {
+                // No shell: a property's label is whatever its author wrote.
+                const picker = ["zenity", "--file-selection"];
+                if (property.type === "directory") picker.push("--directory");
+                picker.push("--title", propertyLabel(property));
+
+                execAsync(picker)
+                  .then((path) => {
+                    const chosen = path.trim();
+                    if (!chosen) return;
+                    apply(property, chosen);
+                    self.label = (chosen.split("/").pop() ?? chosen).slice(0, 20);
+                    self.tooltipText = chosen;
+                  })
+                  .catch(() => {});
+              }}
+            />
+          </box>
+        );
+
+      default:
+        return (
+          <box class="property" spacing={5}>
+            {title}
+            <entry
+              halign={Gtk.Align.END}
+              text={String(value ?? "")}
+              onActivate={(self) => apply(property, self.text)}
+            />
+          </box>
+        );
+    }
+  };
+
+  return (
+    <box
+      class="wallpaper-engine-properties"
+      orientation={Gtk.Orientation.VERTICAL}
+      spacing={10}
+      $={load}
+    >
+      <box spacing={10}>
+        <label class="title" hexpand xalign={0} label={item.title} />
+        <button
+          class="reset"
+          label="󰑐"
+          tooltipText="Reset this wallpaper's settings"
+          onClicked={reset}
+        />
+      </box>
+
+      <With value={status}>
+        {(text) => text && <label class="status" wrap label={text} />}
+      </With>
+
+      <scrolledwindow
+        class="properties"
+        propagateNaturalHeight
+        maxContentHeight={420}
+        hscrollbarPolicy={Gtk.PolicyType.NEVER}
+      >
+        <box orientation={Gtk.Orientation.VERTICAL} spacing={10}>
+          <For each={properties}>{(property) => Property(property)}</For>
+        </box>
+      </scrolledwindow>
+    </box>
+  );
+}

--- a/.config/ags/widgets/WallpaperEngineProperties.tsx
+++ b/.config/ags/widgets/WallpaperEngineProperties.tsx
@@ -52,19 +52,44 @@ const wireValue = (value: any): string => String(value);
 /// markup nobody can read. Tags come out, entities are decoded, whitespace
 /// collapses, and a label that was *only* markup falls back to its key.
 function plainText(raw: string): string {
-  const stripped = raw
-    // Anything inside a tag goes; an <img> or <a> carries no text of its own.
-    .replace(/<[^>]*>/g, " ")
-    .replace(/&nbsp;/gi, " ")
-    .replace(/&amp;/gi, "&")
-    .replace(/&lt;/gi, "<")
-    .replace(/&gt;/gi, ">")
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/\s+/g, " ")
-    .trim();
+  // Entities are decoded FIRST and tags stripped after, repeatedly: a label
+  // that arrives as `&lt;center&gt;&lt;a href=…` is markup wearing a
+  // disguise, and stripping before decoding just unwraps it into visible
+  // tag soup — which is exactly what the settings panel was showing.
+  const decode = (text: string) =>
+    text
+      .replace(/&nbsp;/gi, " ")
+      .replace(/&lt;/gi, "<")
+      .replace(/&gt;/gi, ">")
+      .replace(/&quot;/gi, '"')
+      .replace(/&#0?39;/g, "'")
+      .replace(/&amp;/gi, "&");
+
+  let text = raw;
+  for (let pass = 0; pass < 3; pass += 1) {
+    const next = decode(text).replace(/<[^>]*>/g, " ");
+    if (next === text) break;
+    text = next;
+  }
+
+  const stripped = text.replace(/\s+/g, " ").trim();
   // A bare URL left behind by a stripped link is not a label either.
   return /^https?:\/\/\S*$/.test(stripped) ? "" : stripped;
+}
+
+/// Whether a property is a banner rather than a setting.
+///
+/// Wallpaper authors use label-only properties as decoration — a credit link,
+/// a QQ group, a picture of themselves. Their `text` is pure markup, and the
+/// key kirie derives from it is that same markup with the punctuation gone
+/// ("centerahrefhttpsspacebilibilicom5890295imgsrc…"), so neither is showable.
+/// The row carries no control worth keeping either, so it does not get drawn.
+function isBanner(property: KirieProperty): boolean {
+  const raw = property.text ?? "";
+  if (!raw.trim()) return false;
+  // Wrote something, and none of it survived being read as text ⇒ it was
+  // markup all the way down.
+  return plainText(raw) === "";
 }
 
 function propertyLabel(property: KirieProperty): string {
@@ -340,7 +365,15 @@ export default function WallpaperEngineProperties({
         hscrollbarPolicy={Gtk.PolicyType.NEVER}
       >
         <box orientation={Gtk.Orientation.VERTICAL} spacing={10}>
-          <For each={properties}>{(property) => Property(property)}</For>
+          <For each={properties}>
+            {(property) =>
+              isBanner(property) ? (
+                <box visible={false} />
+              ) : (
+                Property(property)
+              )
+            }
+          </For>
         </box>
       </scrolledwindow>
     </box>

--- a/.config/ags/widgets/WallpaperEngineProperties.tsx
+++ b/.config/ags/widgets/WallpaperEngineProperties.tsx
@@ -5,6 +5,7 @@ import GLib from "gi://GLib";
 import { execAsync } from "ags/process";
 import { timeout } from "ags/time";
 import { notify } from "../utils/notification";
+import ColorPicker from "./ColorPicker";
 import { readJSONFile, writeJSONFile } from "../utils/json";
 import {
   KirieItem,
@@ -188,10 +189,18 @@ export default function WallpaperEngineProperties({
                   )?.label ?? String(value)
                 }
               />
-              <popover>
+              {/* Beside the row, not on top of it: the panel is a dense
+                  column, and a popover pointing down covers the very settings
+                  the choice is being compared against. */}
+              <popover position={Gtk.PositionType.LEFT}>
                 <box orientation={Gtk.Orientation.VERTICAL} class="popover">
                   {(property.options ?? []).map((option) => (
                     <button
+                      class={
+                        String(option.value) === String(value)
+                          ? "selected"
+                          : ""
+                      }
                       label={option.label}
                       onClicked={(self) => {
                         apply(property, option.value);
@@ -212,15 +221,9 @@ export default function WallpaperEngineProperties({
         return (
           <box class="property" spacing={5}>
             {title}
-            <Gtk.ColorDialogButton
-              halign={Gtk.Align.END}
-              dialog={new Gtk.ColorDialog({ withAlpha: false })}
+            <ColorPicker
               rgba={tripleToRgba(value)}
-              $={(self: Gtk.ColorDialogButton) =>
-                self.connect("notify::rgba", () =>
-                  apply(property, rgbaToTriple(self.get_rgba())),
-                )
-              }
+              onPicked={(picked) => apply(property, rgbaToTriple(picked))}
             />
           </box>
         );

--- a/.config/ags/widgets/WallpaperSwitcher.tsx
+++ b/.config/ags/widgets/WallpaperSwitcher.tsx
@@ -19,7 +19,13 @@ import { Gdk } from "ags/gtk4";
 import { formatKiloBytes } from "../utils/bytes";
 import { readJson } from "../utils/json";
 import GLib from "gi://GLib";
-import { KirieItem, kirieInstalled, kirieList } from "../services/kirie";
+import {
+  KirieItem,
+  kirieCurrentItem,
+  kirieInstalled,
+  kirieList,
+} from "../services/kirie";
+import WallpaperEngineProperties from "./WallpaperEngineProperties";
 
 // Wallpaper Engine items are directories rather than files, so they are kept
 // beside the folder wallpapers under their own category and looked up by the
@@ -105,6 +111,15 @@ export default ({
   const [targetType, setTargetType] = createState<string>("workspace");
 
   const [wallpapers, setWallpapers] = createState<Record<string, string[]>>({});
+
+  // The engine item whose settings the properties popover is showing.
+  const [propertiesItem, setPropertiesItem] = createState<KirieItem | null>(
+    null,
+  );
+  let propertiesButton: Gtk.MenuButton | null = null;
+  // Set when a right-click picked the item, so opening the button on its own
+  // still falls back to whatever is on this monitor.
+  let pickedItem = false;
 
   const selectedWallpapers = createComputed(() => {
     return (
@@ -258,13 +273,13 @@ export default ({
                 };
 
                 const handleRightClick = () => {
-                  // Steam owns the engine items; deleting one here would only
-                  // break the subscription it belongs to.
-                  if (engineItem(wallpaper)) {
-                    notify({
-                      summary: "Wallpaper Engine",
-                      body: "Unsubscribe from this item in Steam to remove it.",
-                    });
+                  // Steam owns the engine items, so right-click opens their
+                  // settings instead of deleting them.
+                  const item = engineItem(wallpaper);
+                  if (item) {
+                    pickedItem = true;
+                    setPropertiesItem(item);
+                    propertiesButton?.popup();
                     return;
                   }
 
@@ -330,6 +345,7 @@ export default ({
                       if (item)
                         return (
                           `Click to set as <b>${type}</b> wallpaper.` +
+                          "\nRight-click for its settings." +
                           `\n ${item.title}` +
                           `\n Wallpaper Engine ${item.type}`
                         );
@@ -591,6 +607,48 @@ export default ({
       </menubutton>
     );
 
+    const propertiesSelector = (
+      <menubutton
+        class="wallpaper-properties"
+        valign={Gtk.Align.CENTER}
+        visible={kirieInstalled()}
+        tooltipMarkup="<b>Wallpaper Engine</b> settings for this wallpaper"
+        $={(self) => {
+          propertiesButton = self;
+          self.connect("notify::active", () => {
+            if (!self.active) {
+              pickedItem = false;
+              return;
+            }
+            if (pickedItem) return;
+            kirieCurrentItem(monitorName).then((dir) =>
+              setPropertiesItem(engineItem(dir) ?? null),
+            );
+          });
+        }}
+      >
+        <label label="󰒓" />
+        <popover>
+          <With value={propertiesItem}>
+            {(item) =>
+              item ? (
+                <WallpaperEngineProperties monitor={monitorName} item={item} />
+              ) : (
+                <label
+                  class="popover"
+                  wrap
+                  label={
+                    "No Wallpaper Engine wallpaper here.\n" +
+                    "Right-click one to edit its settings."
+                  }
+                />
+              )
+            }
+          </With>
+        </popover>
+      </menubutton>
+    );
+
     const actions = (
       <box
         class="actions"
@@ -602,6 +660,7 @@ export default ({
         {selectedWorkspaceLabel}
         {displayColorScheme}
         {categorySelector}
+        {propertiesSelector}
         {randomButton}
         {resetButton}
         {addWallpaper}

--- a/.config/ags/widgets/WallpaperSwitcher.tsx
+++ b/.config/ags/widgets/WallpaperSwitcher.tsx
@@ -26,6 +26,7 @@ import {
   kirieList,
 } from "../services/kirie";
 import WallpaperEngineProperties from "./WallpaperEngineProperties";
+import WorkshopBrowser from "./WorkshopBrowser";
 
 // Wallpaper Engine items are directories rather than files, so they are kept
 // beside the folder wallpapers under their own category and looked up by the
@@ -675,6 +676,38 @@ export default ({
       </menubutton>
     );
 
+    // Browse the Workshop for wallpapers this machine does not have yet — the
+    // one thing the rest of this switcher cannot show, since it lists what is
+    // installed. Subscribing puts the item exactly where `kirie list` looks.
+    const workshopSelector = (
+      <menubutton
+        class="workshop"
+        visible={kirieInstalled()}
+        tooltipMarkup="Browse the <b>Steam Workshop</b>"
+      >
+        <label label="󰇚" />
+        <popover position={Gtk.PositionType.TOP}>
+          <WorkshopBrowser
+            onApply={(dir) => {
+              setProgressStatus("loading");
+              execAsync([
+                `${GLib.get_home_dir()}/.config/hypr/wallpaper-daemon/set-wallpaper.sh`,
+                wallpaperTarget(),
+                monitorName,
+                dir,
+              ])
+                .then(() => FetchCurrentWallpapers(monitorName))
+                .finally(() => setProgressStatus("success"))
+                .catch((err) => {
+                  setProgressStatus("error");
+                  notify({ summary: "Error", body: String(err) });
+                });
+            }}
+          />
+        </popover>
+      </menubutton>
+    );
+
     const actions = (
       <box
         class="actions"
@@ -687,6 +720,7 @@ export default ({
         {displayColorScheme}
         {categorySelector}
         {propertiesSelector}
+        {workshopSelector}
         {randomButton}
         {resetButton}
         {addWallpaper}

--- a/.config/ags/widgets/WallpaperSwitcher.tsx
+++ b/.config/ags/widgets/WallpaperSwitcher.tsx
@@ -130,12 +130,58 @@ export default ({
   // still falls back to whatever is on this monitor.
   let pickedItem = false;
 
+  /// How the strip is ordered. "Newest" is what a growing library wants —
+  /// something just subscribed to is at the end of a scan and off the side of
+  /// the screen otherwise.
+  const ORDERS = ["Newest", "Oldest", "Name", "Type"] as const;
+  const [order, setOrder] = createState<(typeof ORDERS)[number]>("Newest");
+
+  /// When the file (or item directory) was last written, as a Unix time.
+  ///
+  /// Steam writes the directory as it downloads, so for a Workshop item this
+  /// is when it arrived on this machine, which is what "newest" should mean
+  /// here — not when its author last published it.
+  const writtenAt = (path: string): number => {
+    try {
+      return (
+        Gio.File.new_for_path(path)
+          .query_info("time::modified", Gio.FileQueryInfoFlags.NONE, null)
+          .get_attribute_uint64("time::modified") || 0
+      );
+    } catch (_err) {
+      return 0;
+    }
+  };
+
+  const nameOf = (path: string) =>
+    (engineItem(path)?.title ?? path.split("/").pop() ?? path).toLowerCase();
+
   const selectedWallpapers = createComputed(() => {
-    return (
-      wallpapers()[
+    const paths = [
+      ...(wallpapers()[
         globalSettings(({ wallpaperSwitcher }) => wallpaperSwitcher.category)()
-      ] || []
-    );
+      ] || []),
+    ];
+
+    switch (order()) {
+      case "Newest":
+        return paths.sort((a, b) => writtenAt(b) - writtenAt(a));
+      case "Oldest":
+        return paths.sort((a, b) => writtenAt(a) - writtenAt(b));
+      case "Name":
+        return paths.sort((a, b) => nameOf(a).localeCompare(nameOf(b)));
+      case "Type":
+        // Group the engine's kinds together, then name within each kind.
+        return paths.sort((a, b) => {
+          const kind = (path: string) =>
+            engineItem(path)?.type ?? path.split(".").pop() ?? "";
+          return (
+            kind(a).localeCompare(kind(b)) || nameOf(a).localeCompare(nameOf(b))
+          );
+        });
+      default:
+        return paths;
+    }
   });
 
   async function FetchWallpapers() {
@@ -151,6 +197,32 @@ export default ({
       print("Error fetching wallpapers: " + String(err));
     }
   }
+
+  /// Drop one wallpaper from the list without waiting for a rescan.
+  ///
+  /// Unsubscribing tells Steam to let go; Steam then deletes the files when it
+  /// gets to it, usually seconds later. Rescanning immediately therefore finds
+  /// the item still on disk and puts it straight back — it took a second
+  /// unsubscribe to make it go, which was the shell lagging behind the user
+  /// rather than anything being wrong.
+  const forget = (path: string) => {
+    const next: Record<string, string[]> = {};
+    for (const [category, paths] of Object.entries(wallpapers.peek())) {
+      next[category] = paths.filter((entry) => entry !== path);
+    }
+    setWallpapers(next);
+  };
+
+  /// Rescan once the directory has actually gone, so the list settles on the
+  /// truth rather than on the optimistic removal above. Gives up after 15s;
+  /// Steam has its own ideas about when to tidy up.
+  const rescanWhenGone = (path: string, attemptsLeft = 15) => {
+    if (attemptsLeft <= 0 || !GLib.file_test(path, GLib.FileTest.EXISTS)) {
+      FetchWallpapers();
+      return;
+    }
+    timeout(1000, () => rescanWhenGone(path, attemptsLeft - 1));
+  };
 
   const [currentWallpapers, setCurrentWallpapers] = createState<string[]>([]);
 
@@ -398,20 +470,21 @@ export default ({
                         () => {
                           setProgressStatus("loading");
                           kirieWorkshopUnsubscribe(item.id)
-                            .then(() =>
+                            .then(() => {
+                              // Gone from the list now, gone from disk when
+                              // Steam catches up.
+                              forget(wallpaper);
+                              rescanWhenGone(wallpaper);
                               notify({
                                 summary: "Unsubscribed",
-                                body: `${item.title}
-Steam removes the files when it next runs.`,
-                              }),
-                            )
-                            .catch((err) =>
-                              notify({ summary: "Error", body: String(err) }),
-                            )
-                            .finally(() => {
+                                body: item.title,
+                              });
+                            })
+                            .catch((err) => {
+                              notify({ summary: "Error", body: String(err) });
                               FetchWallpapers();
-                              setProgressStatus("success");
-                            });
+                            })
+                            .finally(() => setProgressStatus("success"));
                         },
                         "destructive",
                       ),
@@ -820,6 +893,29 @@ Steam removes the files when it next runs.`,
       </menubutton>
     );
 
+    const orderSelector = (
+      <menubutton class="order-selector" tooltipMarkup="Order the wallpapers">
+        <box spacing={4}>
+          <label label={order((o) => o)} />
+          <label class="chevron" label="▾" />
+        </box>
+        <popover position={Gtk.PositionType.TOP}>
+          <box orientation={Gtk.Orientation.VERTICAL} class="popover">
+            {ORDERS.map((option) => (
+              <button
+                class={order((o) => (o === option ? "selected" : ""))}
+                label={option}
+                onClicked={(self: Gtk.Button) => {
+                  (self.get_ancestor(Gtk.Popover) as Gtk.Popover)?.popdown();
+                  setOrder(option);
+                }}
+              />
+            ))}
+          </box>
+        </popover>
+      </menubutton>
+    );
+
     const actions = (
       <box
         class="actions"
@@ -831,6 +927,7 @@ Steam removes the files when it next runs.`,
         {selectedWorkspaceLabel}
         {displayColorScheme}
         {categorySelector}
+        {orderSelector}
         {propertiesSelector}
         {workshopSelector}
         {randomButton}

--- a/.config/ags/widgets/WallpaperSwitcher.tsx
+++ b/.config/ags/widgets/WallpaperSwitcher.tsx
@@ -24,6 +24,7 @@ import {
   kirieCurrentItem,
   kirieInstalled,
   kirieList,
+  kirieWallpaperEngineInstalled,
   kirieWorkshopUnsubscribe,
 } from "../services/kirie";
 import WallpaperEngineProperties from "./WallpaperEngineProperties";
@@ -236,6 +237,12 @@ export default ({
     }
     timeout(1000, () => rescanWhenGone(path, attemptsLeft - 1));
   };
+
+  // kirie being installed is not enough to offer its surface: every scene
+  // wallpaper needs Wallpaper Engine's shared assets, so without them these
+  // controls act on nothing.
+  const [engineReady, setEngineReady] = createState<boolean>(false);
+  kirieWallpaperEngineInstalled().then(setEngineReady);
 
   const [currentWallpapers, setCurrentWallpapers] = createState<string[]>([]);
 
@@ -835,7 +842,7 @@ export default ({
       <menubutton
         class="wallpaper-properties"
         valign={Gtk.Align.CENTER}
-        visible={kirieInstalled()}
+        visible={engineReady((ready) => ready)}
         tooltipMarkup="<b>Wallpaper Engine</b> settings for this wallpaper"
         $={(self) => {
           propertiesButton = self;
@@ -879,7 +886,7 @@ export default ({
     const workshopSelector = (
       <menubutton
         class="workshop"
-        visible={kirieInstalled()}
+        visible={engineReady((ready) => ready)}
         tooltipMarkup="Browse the <b>Steam Workshop</b>"
       >
         {/* Steam's own mark, alone. A download arrow said "fetch something"

--- a/.config/ags/widgets/WallpaperSwitcher.tsx
+++ b/.config/ags/widgets/WallpaperSwitcher.tsx
@@ -221,6 +221,19 @@ export default ({
       FetchWallpapers();
       return;
     }
+    // Steam deletes the files it owns and stops there, so an item kirie has
+    // rendered keeps its directory alive through the shader cache kirie left
+    // inside it. That ghost is ours to clear — but only once nothing of the
+    // wallpaper itself is left, which is what the missing project.json says.
+    if (
+      !GLib.file_test(`${path}/project.json`, GLib.FileTest.EXISTS) &&
+      GLib.file_test(`${path}/.kirie-cache`, GLib.FileTest.IS_DIR)
+    ) {
+      execAsync(["rm", "-rf", "--", path])
+        .catch(() => {})
+        .finally(() => FetchWallpapers());
+      return;
+    }
     timeout(1000, () => rescanWhenGone(path, attemptsLeft - 1));
   };
 

--- a/.config/ags/widgets/WallpaperSwitcher.tsx
+++ b/.config/ags/widgets/WallpaperSwitcher.tsx
@@ -19,8 +19,68 @@ import { Gdk } from "ags/gtk4";
 import { formatKiloBytes } from "../utils/bytes";
 import { readJson } from "../utils/json";
 import GLib from "gi://GLib";
+import { KirieItem, kirieInstalled, kirieList } from "../services/kirie";
+
+// Wallpaper Engine items are directories rather than files, so they are kept
+// beside the folder wallpapers under their own category and looked up by the
+// path that gets stored as the wallpaper.
+export const engineCategory = "wallpaper engine";
+// GtkPicture hands back a placeholder for the animated previews these items
+// ship, so those get a still frame cached beside the folder thumbnails.
+const engineThumbnails = `${GLib.get_home_dir()}/.config/ags/cache/thumbnails/wallpaper-engine`;
+const isAnimated = (preview: string) => preview.toLowerCase().endsWith(".gif");
+const engineThumbnail = (item: KirieItem) =>
+  item.preview && isAnimated(item.preview)
+    ? `${engineThumbnails}/${item.id}.jpg`
+    : (item.preview ?? "");
+
+/** Make the still frames the animated previews need, once per item. */
+async function makeEngineThumbnails(items: KirieItem[]) {
+  const missing = items.filter(
+    (item) =>
+      item.preview &&
+      isAnimated(item.preview) &&
+      !GLib.file_test(engineThumbnail(item), GLib.FileTest.EXISTS),
+  );
+  if (missing.length === 0) return;
+
+  const jobs = missing
+    .map(
+      (item) =>
+        `magick ${JSON.stringify(`${item.preview}[0]`)} -resize 256x256 ` +
+        `-quality 85 -strip ${JSON.stringify(engineThumbnail(item))} &`,
+    )
+    .join("\n");
+
+  await execAsync([
+    "bash",
+    "-c",
+    `mkdir -p ${JSON.stringify(engineThumbnails)}\n${jobs}\nwait`,
+  ]).catch((err) => print("Error making engine thumbnails: " + String(err)));
+}
+const [engineItems, setEngineItems] = createState<Record<string, KirieItem>>({});
+export const engineItem = (path: string): KirieItem | undefined =>
+  engineItems.peek()[path];
+
+/** The installed engine items as a wallpaper category, empty when kirie is
+ * not installed or has nothing this build can render. */
+async function fetchEngineWallpapers(): Promise<Record<string, string[]>> {
+  if (!kirieInstalled()) return {};
+  try {
+    const items = (await kirieList()).filter((item) => item.renderable);
+    await makeEngineThumbnails(items);
+    setEngineItems(Object.fromEntries(items.map((item) => [item.dir, item])));
+    return items.length ? { [engineCategory]: items.map((item) => item.dir) } : {};
+  } catch (err) {
+    print("Error listing wallpaper engine items: " + String(err));
+    return {};
+  }
+}
 
 export function toThumbnailPath(file: string) {
+  const item = engineItem(file);
+  if (item) return engineThumbnail(item);
+
   return file
     .replace("/.config/wallpapers/", "/.config/ags/cache/thumbnails/")
     .replace(/\.[^/.]+$/, ".jpg");
@@ -61,7 +121,7 @@ export default ({
         `bash ${GLib.get_home_dir()}/.config/ags/scripts/get-wallpapers.sh`,
       );
       const wallpapers = readJson(output);
-      setWallpapers(wallpapers);
+      setWallpapers({ ...wallpapers, ...(await fetchEngineWallpapers()) });
     } catch (err) {
       notify({ summary: "Error", body: String(err) });
       print("Error fetching wallpapers: " + String(err));
@@ -132,7 +192,9 @@ export default ({
                         file={toThumbnailPath(wallpaper)}
                         info={[
                           String(workspaceId + 1),
-                          wallpaper.split(".").pop() || "unknown",
+                          engineItem(wallpaper)?.type ||
+                            wallpaper.split(".").pop() ||
+                            "unknown",
                         ]}
                       ></Picture>
                     )}
@@ -196,6 +258,16 @@ export default ({
                 };
 
                 const handleRightClick = () => {
+                  // Steam owns the engine items; deleting one here would only
+                  // break the subscription it belongs to.
+                  if (engineItem(wallpaper)) {
+                    notify({
+                      summary: "Wallpaper Engine",
+                      body: "Unsubscribe from this item in Steam to remove it.",
+                    });
+                    return;
+                  }
+
                   setProgressStatus("loading");
                   execAsync(
                     `bash -c "rm -f '${toThumbnailPath(
@@ -253,21 +325,34 @@ export default ({
 
                       self.add_controller(gesture);
                     }}
-                    tooltipMarkup={targetType(
-                      (type) =>
+                    tooltipMarkup={targetType((type) => {
+                      const item = engineItem(wallpaper);
+                      if (item)
+                        return (
+                          `Click to set as <b>${type}</b> wallpaper.` +
+                          `\n ${item.title}` +
+                          `\n Wallpaper Engine ${item.type}`
+                        );
+
+                      return (
                         "Click to set as <b>" +
                         type +
                         "</b> wallpaper.\nRight-click to delete." +
                         // get filename from path
                         `\n ${wallpaper.split("/").pop()}` +
                         // file size
-                        `\n Size: ${fileSize(wallpaper)}`,
-                    )}
+                        `\n Size: ${fileSize(wallpaper)}`
+                      );
+                    })}
                   >
                     <Picture
                       class="wallpaper"
                       file={toThumbnailPath(wallpaper)}
-                      info={[wallpaper.split(".").pop() || "unknown"]}
+                      info={[
+                        engineItem(wallpaper)?.type ||
+                          wallpaper.split(".").pop() ||
+                          "unknown",
+                      ]}
                     ></Picture>
                   </button>
                 ) as Gtk.Widget;
@@ -557,7 +642,9 @@ export default ({
       $={async (self) => {
         setup(self);
         (self as any).monitorName = monitorName;
-        FetchWallpapers();
+        // The engine items have to be known before the current wallpapers are
+        // drawn, or the ones set from an item render without their preview.
+        await FetchWallpapers();
         FetchCurrentWallpapers(monitorName);
 
         // Initialize selected workspace

--- a/.config/ags/widgets/WallpaperSwitcher.tsx
+++ b/.config/ags/widgets/WallpaperSwitcher.tsx
@@ -869,7 +869,12 @@ export default ({
         visible={kirieInstalled()}
         tooltipMarkup="Browse the <b>Steam Workshop</b>"
       >
-        <label label="󰇚" />
+        {/* Steam's own mark with a magnifier beside it: a download arrow said
+            "fetch something", not "go and look through the Workshop". */}
+        <box class="workshop-icon" spacing={1}>
+          <label class="steam" label="" />
+          <label class="lens" label="󰍉" />
+        </box>
         <popover position={Gtk.PositionType.TOP}>
           <WorkshopBrowser
             onInstalled={() => FetchWallpapers()}

--- a/.config/ags/widgets/WallpaperSwitcher.tsx
+++ b/.config/ags/widgets/WallpaperSwitcher.tsx
@@ -112,6 +112,13 @@ export default ({
 
   const [wallpapers, setWallpapers] = createState<Record<string, string[]>>({});
 
+  // In global mode one wallpaper covers every workspace, so the wallpaper is
+  // stored under the daemon's `global` slot instead of a workspace one.
+  const wallpaperMode = globalSettings(({ wallpaper }) => wallpaper.mode.value);
+  const isGlobal = () => wallpaperMode.peek() === "global";
+  const wallpaperTarget = () =>
+    isGlobal() ? "global" : String(selectedWorkspaceId.peek());
+
   // The engine item whose settings the properties popover is showing.
   const [propertiesItem, setPropertiesItem] = createState<KirieItem | null>(
     null,
@@ -192,7 +199,11 @@ export default ({
                       setTargetType("workspace");
                       setSelectedWorkspaceId(workspaceId + 1);
                     }}
-                    tooltipMarkup={`Set wallpaper for <b>Workspace ${workspaceId + 1}</b>`}
+                    tooltipMarkup={
+                      wallpaperMode.peek() === "global"
+                        ? "The <b>global</b> wallpaper, used on every workspace"
+                        : `Set wallpaper for <b>Workspace ${workspaceId + 1}</b>`
+                    }
                   >
                     {wallpaper == "" ? (
                       <label
@@ -206,7 +217,9 @@ export default ({
                         class="wallpaper"
                         file={toThumbnailPath(wallpaper)}
                         info={[
-                          String(workspaceId + 1),
+                          wallpaperMode.peek() === "global"
+                            ? "global"
+                            : String(workspaceId + 1),
                           engineItem(wallpaper)?.type ||
                             wallpaper.split(".").pop() ||
                             "unknown",
@@ -250,7 +263,7 @@ export default ({
                     ],
                     workspace: [
                       `${GLib.get_home_dir()}/.config/hypr/wallpaper-daemon/set-wallpaper.sh`,
-                      String(selectedWorkspaceId.peek()),
+                      wallpaperTarget(),
                       String((self.get_root() as any).monitorName),
                       wallpaper,
                     ],
@@ -412,7 +425,7 @@ export default ({
             ];
           execAsync([
             `${GLib.get_home_dir()}/.config/hypr/wallpaper-daemon/set-wallpaper.sh`,
-            String(selectedWorkspaceId.peek()),
+            wallpaperTarget(),
             String((self.get_root() as any).monitorName),
             randomWallpaper,
           ])
@@ -449,9 +462,11 @@ export default ({
         class="selected-workspace"
         label={createComputed(
           () =>
-            `Wallpaper -> ${targetType()} ${
-              targetType() === "workspace" ? selectedWorkspaceId() : ""
-            }`,
+            targetType() !== "workspace"
+              ? `Wallpaper -> ${targetType()}`
+              : wallpaperMode() === "global"
+                ? "Wallpaper -> global"
+                : `Wallpaper -> workspace ${selectedWorkspaceId()}`,
         )}
         $={(self) =>
           createComputed([selectedWorkspaceId, targetType]).subscribe(() => {
@@ -705,6 +720,8 @@ export default ({
         // drawn, or the ones set from an item render without their preview.
         await FetchWallpapers();
         FetchCurrentWallpapers(monitorName);
+
+        wallpaperMode.subscribe(() => FetchCurrentWallpapers(monitorName));
 
         // Initialize selected workspace
         focusedWorkspace.subscribe(() => {

--- a/.config/ags/widgets/WallpaperSwitcher.tsx
+++ b/.config/ags/widgets/WallpaperSwitcher.tsx
@@ -178,7 +178,13 @@ export default ({
     const getCurrentWorkspaces = (
       <box>
         <With value={currentWallpapers}>
-          {(wallpapers) => {
+          {(fetched) => {
+            // One wallpaper covers every workspace in global mode, so it is
+            // drawn once. Slicing here (rather than trusting the fetch) means
+            // the row is right the moment the mode changes, before the daemon
+            // has rewritten its config.
+            const wallpapers =
+              wallpaperMode.peek() === "global" ? fetched.slice(0, 1) : fetched;
             return (
               <box
                 hexpand={true}
@@ -190,7 +196,12 @@ export default ({
                   <button
                     class={focusedWorkspace((workspace) => {
                       const i = workspace?.id || 1;
-                      return i === workspaceId + 1
+                      // The single global tile is always the live one; keying
+                      // it off the focused workspace would light it up only on
+                      // workspace 1.
+                      const isCurrent =
+                        wallpaperMode.peek() === "global" || i === workspaceId + 1;
+                      return isCurrent
                         ? "wallpaper-button focused"
                         : "wallpaper-button";
                     })}
@@ -721,6 +732,15 @@ export default ({
         await FetchWallpapers();
         FetchCurrentWallpapers(monitorName);
 
+        // Switching the mode writes the daemon's config from a script that is
+        // still running when the setting itself changes, so refetching on the
+        // setting alone reads the OLD layout and sticks there — ten workspace
+        // tiles labelled "global". Follow the file the daemon actually writes:
+        // it also covers wallpapers changed by anything other than this panel.
+        monitorFile(
+          `${GLib.get_home_dir()}/.config/hypr/wallpaper-daemon/config/${monitorName}/defaults.conf`,
+          () => FetchCurrentWallpapers(monitorName),
+        );
         wallpaperMode.subscribe(() => FetchCurrentWallpapers(monitorName));
 
         // Initialize selected workspace

--- a/.config/ags/widgets/WallpaperSwitcher.tsx
+++ b/.config/ags/widgets/WallpaperSwitcher.tsx
@@ -24,6 +24,7 @@ import {
   kirieCurrentItem,
   kirieInstalled,
   kirieList,
+  kirieWorkshopUnsubscribe,
 } from "../services/kirie";
 import WallpaperEngineProperties from "./WallpaperEngineProperties";
 import WorkshopBrowser from "./WorkshopBrowser";
@@ -297,38 +298,148 @@ export default ({
                     });
                 };
 
-                const handleRightClick = () => {
-                  // Steam owns the engine items, so right-click opens their
-                  // settings instead of deleting them.
-                  const item = engineItem(wallpaper);
-                  if (item) {
-                    pickedItem = true;
-                    setPropertiesItem(item);
-                    propertiesButton?.popup();
-                    return;
-                  }
-
+                // Right-click used to mean two different things depending on
+                // what was under the cursor — settings for an engine item,
+                // and an *unconfirmed delete* for anything else. It opens a
+                // menu instead: the destructive entries are then something
+                // chosen rather than something triggered.
+                const deleteWallpaper = () => {
                   setProgressStatus("loading");
-                  execAsync(
-                    `bash -c "rm -f '${toThumbnailPath(
-                      wallpaper,
-                    )}' && rm -f '${wallpaper}'"`,
-                  )
+                  execAsync([
+                    "bash",
+                    "-c",
+                    `rm -f '${toThumbnailPath(wallpaper)}' && rm -f '${wallpaper}'`,
+                  ])
                     .then(() =>
-                      notify({
-                        summary: "Success",
-                        body: "Wallpaper deleted successfully!",
-                      }),
+                      notify({ summary: "Wallpaper", body: "Deleted." }),
                     )
                     .catch((err) => {
                       setProgressStatus("error");
                       notify({ summary: "Error", body: String(err) });
-                      throw err;
                     })
                     .finally(() => {
                       FetchWallpapers();
                       setProgressStatus("success");
                     });
+                };
+
+                const copy = (text: string, what: string) =>
+                  execAsync(["wl-copy", text])
+                    .then(() => notify({ summary: what, body: text }))
+                    .catch((err) =>
+                      notify({ summary: "Error", body: String(err) }),
+                    );
+
+                const menuEntry = (
+                  label: string,
+                  action: () => void,
+                  cssClass = "",
+                ) =>
+                  (
+                    <button
+                      class={cssClass}
+                      label={label}
+                      onClicked={(self: Gtk.Button) => {
+                        (
+                          self.get_ancestor(Gtk.Popover) as Gtk.Popover
+                        )?.popdown();
+                        action();
+                      }}
+                    />
+                  ) as Gtk.Widget;
+
+                /// The menu for one wallpaper, built on first right-click.
+                const buildMenu = (button: Gtk.Widget) => {
+                  const item = engineItem(wallpaper);
+                  const entries: Gtk.Widget[] = [];
+
+                  if (item) {
+                    entries.push(
+                      menuEntry("Settings", () => {
+                        pickedItem = true;
+                        setPropertiesItem(item);
+                        propertiesButton?.popup();
+                      }),
+                      menuEntry("Copy Workshop link", () =>
+                        copy(
+                          `https://steamcommunity.com/sharedfiles/filedetails/?id=${item.id}`,
+                          "Workshop link",
+                        ),
+                      ),
+                      menuEntry("Open in Steam", () =>
+                        execAsync([
+                          "xdg-open",
+                          `steam://url/CommunityFilePage/${item.id}`,
+                        ]).catch((err) =>
+                          notify({ summary: "Error", body: String(err) }),
+                        ),
+                      ),
+                    );
+                  }
+
+                  entries.push(
+                    menuEntry("Copy path", () => copy(wallpaper, "Path")),
+                    menuEntry("Open folder", () =>
+                      execAsync([
+                        "xdg-open",
+                        item ? wallpaper : wallpaper.split("/").slice(0, -1).join("/"),
+                      ]).catch((err) =>
+                        notify({ summary: "Error", body: String(err) }),
+                      ),
+                    ),
+                  );
+
+                  if (item) {
+                    // Steam owns these files; unsubscribing is how they go,
+                    // and Steam removes them on its own schedule afterwards.
+                    entries.push(
+                      menuEntry(
+                        "Unsubscribe",
+                        () => {
+                          setProgressStatus("loading");
+                          kirieWorkshopUnsubscribe(item.id)
+                            .then(() =>
+                              notify({
+                                summary: "Unsubscribed",
+                                body: `${item.title}
+Steam removes the files when it next runs.`,
+                              }),
+                            )
+                            .catch((err) =>
+                              notify({ summary: "Error", body: String(err) }),
+                            )
+                            .finally(() => {
+                              FetchWallpapers();
+                              setProgressStatus("success");
+                            });
+                        },
+                        "destructive",
+                      ),
+                    );
+                  } else {
+                    entries.push(
+                      menuEntry("Delete", deleteWallpaper, "destructive"),
+                    );
+                  }
+
+                  const popover = new Gtk.Popover({
+                    cssClasses: ["wallpaper-menu"],
+                    position: Gtk.PositionType.TOP,
+                  });
+                  const box = new Gtk.Box({
+                    orientation: Gtk.Orientation.VERTICAL,
+                    cssClasses: ["popover"],
+                  });
+                  for (const entry of entries) box.append(entry);
+                  popover.set_child(box);
+                  popover.set_parent(button);
+                  return popover;
+                };
+
+                let menu: Gtk.Popover | null = null;
+                const handleRightClick = (button: Gtk.Widget) => {
+                  menu ??= buildMenu(button);
+                  menu.popup();
                 };
 
                 const fileSize = (path: string) => {
@@ -360,7 +471,7 @@ export default ({
                       });
 
                       gesture.connect("pressed", () => {
-                        handleRightClick();
+                        handleRightClick(self);
                       });
 
                       self.add_controller(gesture);
@@ -370,7 +481,7 @@ export default ({
                       if (item)
                         return (
                           `Click to set as <b>${type}</b> wallpaper.` +
-                          "\nRight-click for its settings." +
+                          "\nRight-click to manage it." +
                           `\n ${item.title}` +
                           `\n Wallpaper Engine ${item.type}`
                         );
@@ -378,7 +489,7 @@ export default ({
                       return (
                         "Click to set as <b>" +
                         type +
-                        "</b> wallpaper.\nRight-click to delete." +
+                        "</b> wallpaper.\nRight-click to manage it." +
                         // get filename from path
                         `\n ${wallpaper.split("/").pop()}` +
                         // file size
@@ -688,6 +799,7 @@ export default ({
         <label label="󰇚" />
         <popover position={Gtk.PositionType.TOP}>
           <WorkshopBrowser
+            onInstalled={() => FetchWallpapers()}
             onApply={(dir) => {
               setProgressStatus("loading");
               execAsync([

--- a/.config/ags/widgets/WallpaperSwitcher.tsx
+++ b/.config/ags/widgets/WallpaperSwitcher.tsx
@@ -869,12 +869,11 @@ export default ({
         visible={kirieInstalled()}
         tooltipMarkup="Browse the <b>Steam Workshop</b>"
       >
-        {/* Steam's own mark with a magnifier beside it: a download arrow said
-            "fetch something", not "go and look through the Workshop". */}
-        <box class="workshop-icon" spacing={1}>
-          <label class="steam" label="" />
-          <label class="lens" label="󰍉" />
-        </box>
+        {/* Steam's own mark, alone. A download arrow said "fetch something"
+            rather than "go and look through the Workshop", but pairing the
+            mark with a magnifier just made two small glyphs fight for the
+            same button — the tooltip can carry the rest. */}
+        <label class="workshop-icon" label={"\u{f1b6}"} />
         <popover position={Gtk.PositionType.TOP}>
           <WorkshopBrowser
             onInstalled={() => FetchWallpapers()}

--- a/.config/ags/widgets/WorkshopBrowser.tsx
+++ b/.config/ags/widgets/WorkshopBrowser.tsx
@@ -218,6 +218,10 @@ const ensurePreview = async (item: KirieWorkshopItem): Promise<string | null> =>
   return GLib.file_test(path, GLib.FileTest.EXISTS) ? path : null;
 };
 
+/// Groups longer than this get a box to narrow them down; scrolling 25 genres
+/// or 21 resolutions to find one is worse than typing three letters.
+const SEARCHABLE_FROM = 8;
+
 export default function WorkshopBrowser({
   onApply,
   onInstalled,
@@ -337,6 +341,74 @@ export default function WorkshopBrowser({
       }}
     />
   ) as Gtk.Entry;
+
+  /// One filter group's popover: its tags as a list, and — for the long ones —
+  /// a box that narrows the list as it is typed into.
+  const filterPopover = (group: (typeof FILTER_GROUPS)[number]) => {
+    const rows: Gtk.Button[] = [];
+
+    const choose = (tag: string) => (self: Gtk.Button) => {
+      (self.get_ancestor(Gtk.Popover) as Gtk.Popover)?.popdown();
+      setFilter(group.label, tag);
+    };
+
+    const any = (
+      <button class="clear" label={`Any ${group.label.toLowerCase()}`} onClicked={choose("")} />
+    ) as Gtk.Button;
+
+    for (const tag of group.tags) {
+      rows.push(
+        (
+          <button
+            class={filters((f) => (f[group.label] === tag ? "selected" : ""))}
+            label={tag}
+            onClicked={choose(tag)}
+          />
+        ) as Gtk.Button,
+      );
+    }
+
+    const list = (
+      <box orientation={Gtk.Orientation.VERTICAL} class="popover">
+        {any}
+        {rows}
+      </box>
+    ) as Gtk.Widget;
+
+    const narrow = (
+      <entry
+        class="filter-search"
+        placeholderText="Filter…"
+        maxWidthChars={1}
+        $={(self: Gtk.Entry) =>
+          self.connect("changed", () => {
+            const needle = self.text.trim().toLowerCase();
+            for (const row of rows) {
+              row.visible = row.label!.toLowerCase().includes(needle);
+            }
+            // "Any …" is how the group is cleared, so it only hides once the
+            // user is clearly hunting for a specific tag.
+            any.visible = needle === "";
+          })
+        }
+      />
+    ) as Gtk.Widget;
+
+    return (
+      <popover position={Gtk.PositionType.BOTTOM}>
+        <box orientation={Gtk.Orientation.VERTICAL} spacing={4}>
+          {group.tags.length >= SEARCHABLE_FROM ? narrow : <box visible={false} />}
+          <scrolledwindow
+            hscrollbarPolicy={Gtk.PolicyType.NEVER}
+            maxContentHeight={320}
+            propagateNaturalHeight
+          >
+            {list}
+          </scrolledwindow>
+        </box>
+      </popover>
+    );
+  };
 
   const card = (item: KirieWorkshopItem) => {
     const preview = new Gtk.Picture({
@@ -491,36 +563,7 @@ export default function WorkshopBrowser({
               />
               <label class="chevron" label="▾" />
             </box>
-            <popover position={Gtk.PositionType.BOTTOM}>
-              <scrolledwindow
-                hscrollbarPolicy={Gtk.PolicyType.NEVER}
-                maxContentHeight={360}
-                propagateNaturalHeight
-              >
-                <box orientation={Gtk.Orientation.VERTICAL} class="popover">
-                  <button
-                    class="clear"
-                    label={`Any ${group.label.toLowerCase()}`}
-                    onClicked={(self: Gtk.Button) => {
-                      (self.get_ancestor(Gtk.Popover) as Gtk.Popover)?.popdown();
-                      setFilter(group.label, "");
-                    }}
-                  />
-                  {group.tags.map((tag) => (
-                    <button
-                      class={filters((f) =>
-                        f[group.label] === tag ? "selected" : "",
-                      )}
-                      label={tag}
-                      onClicked={(self: Gtk.Button) => {
-                        (self.get_ancestor(Gtk.Popover) as Gtk.Popover)?.popdown();
-                        setFilter(group.label, tag);
-                      }}
-                    />
-                  ))}
-                </box>
-              </scrolledwindow>
-            </popover>
+            {filterPopover(group)}
           </menubutton>
         ))}
         <togglebutton

--- a/.config/ags/widgets/WorkshopBrowser.tsx
+++ b/.config/ags/widgets/WorkshopBrowser.tsx
@@ -40,7 +40,9 @@ const ROWS = 4;
 const PAGE_SIZE = COLUMNS * ROWS;
 
 /// Thumbnail edge. Steam serves square preview images, so the card is square.
-const TILE = 190;
+/// Small on purpose: the panel sits over the desktop, and twelve tiles plus
+/// their filters have to leave the wallpaper behind them visible.
+const TILE = 148;
 
 /// Where downloaded preview thumbnails live.
 const PREVIEW_DIR = `${GLib.get_user_cache_dir()}/ags/workshop-previews`;
@@ -218,9 +220,13 @@ const ensurePreview = async (item: KirieWorkshopItem): Promise<string | null> =>
 
 export default function WorkshopBrowser({
   onApply,
+  onInstalled,
 }: {
   /// Show an installed item. The caller owns which screen and slot that means.
   onApply: (dir: string) => void;
+  /// A subscription finished downloading, so the library behind this panel is
+  /// now a wallpaper short of the truth.
+  onInstalled?: () => void;
 }) {
   const [items, setItems] = createState<KirieWorkshopItem[]>([]);
   const [status, setStatus] = createState<string>("");
@@ -296,6 +302,7 @@ export default function WorkshopBrowser({
             button.set_css_classes(["subscribe", "ready"]);
             if (state.dir) ready(state.dir);
             setStatus(`${item.title} installed`);
+            onInstalled?.();
             return;
           case "error":
             button.label = "Failed";
@@ -386,22 +393,22 @@ export default function WorkshopBrowser({
     ) as Gtk.Button;
 
     return (
-      <box class="workshop-card" orientation={Gtk.Orientation.VERTICAL} spacing={4}>
+      <box class="workshop-card" orientation={Gtk.Orientation.VERTICAL} spacing={2}>
         {preview}
         <label
           class="workshop-title"
           label={item.title}
-          maxWidthChars={18}
+          maxWidthChars={16}
           ellipsize={Pango.EllipsizeMode.END}
           tooltipText={item.title}
         />
-        <box spacing={6} halign={Gtk.Align.CENTER}>
-          <label class="workshop-kind" label={item.type} />
-          <label
-            class="workshop-meta"
-            label={`${Math.round((item.score ?? 0) * 100)}% · ${humanSize(item.size ?? 0)}`}
-          />
-        </box>
+        {/* One line: type, rating and size are all the same kind of fact
+            about the item, and three separate rows made the card twice as
+            tall as its own thumbnail. */}
+        <label
+          class="workshop-meta"
+          label={`${item.type} · ${Math.round((item.score ?? 0) * 100)}% · ${humanSize(item.size ?? 0)}`}
+        />
         {/* Steam knows what the item is; kirie knows whether this build can
             render it, which is the part worth saying before installing. */}
         {!item.renderable && (
@@ -432,14 +439,17 @@ export default function WorkshopBrowser({
     <box
       class="workshop-browser"
       orientation={Gtk.Orientation.VERTICAL}
-      spacing={8}
-      widthRequest={COLUMNS * (TILE + 26)}
-      heightRequest={ROWS * (TILE + 96)}
+      spacing={5}
+      widthRequest={COLUMNS * (TILE + 22)}
+      heightRequest={ROWS * (TILE + 62) + 84}
     >
-      <box spacing={6}>
+      <box spacing={4}>
         {searchEntry}
         <menubutton class="workshop-sort">
-          <label label={sort((s) => SORTS.find((o) => o.value === s)!.label)} />
+          <box spacing={4}>
+            <label label={sort((s) => SORTS.find((o) => o.value === s)!.label)} />
+            <label class="chevron" label="▾" />
+          </box>
           <popover position={Gtk.PositionType.BOTTOM}>
             <box orientation={Gtk.Orientation.VERTICAL} class="popover">
               {SORTS.map((option) => (
@@ -459,23 +469,28 @@ export default function WorkshopBrowser({
 
       <Gtk.FlowBox
         class="workshop-filters"
-        columnSpacing={6}
-        rowSpacing={6}
+        columnSpacing={4}
+        rowSpacing={4}
         selectionMode={Gtk.SelectionMode.NONE}
         homogeneous={false}
-        minChildrenPerLine={3}
-        maxChildrenPerLine={7}
+        minChildrenPerLine={4}
+        maxChildrenPerLine={8}
       >
         {FILTER_GROUPS.map((group) => (
           <menubutton class="workshop-filter">
             {/* The button says what is chosen, not what the group is called:
                 a row of "Type / Age / Genre" tells you nothing about the
-                query you are actually looking at. */}
-            <label
-              label={filters((f) => f[group.label] ?? group.label)}
-              maxWidthChars={16}
-              ellipsize={Pango.EllipsizeMode.END}
-            />
+                query you are actually looking at. The chevron is what says
+                it opens — without one these read as plain labels. */}
+            <box spacing={4}>
+              <label
+                class={filters((f) => (f[group.label] ? "chosen" : ""))}
+                label={filters((f) => f[group.label] ?? group.label)}
+                maxWidthChars={16}
+                ellipsize={Pango.EllipsizeMode.END}
+              />
+              <label class="chevron" label="▾" />
+            </box>
             <popover position={Gtk.PositionType.BOTTOM}>
               <scrolledwindow
                 hscrollbarPolicy={Gtk.PolicyType.NEVER}
@@ -534,8 +549,8 @@ export default function WorkshopBrowser({
         <With value={items}>
           {(list) => (
             <Gtk.FlowBox
-              columnSpacing={8}
-              rowSpacing={8}
+              columnSpacing={6}
+              rowSpacing={6}
               homogeneous={true}
               selectionMode={Gtk.SelectionMode.NONE}
               minChildrenPerLine={COLUMNS}

--- a/.config/ags/widgets/WorkshopBrowser.tsx
+++ b/.config/ags/widgets/WorkshopBrowser.tsx
@@ -64,6 +64,32 @@ const humanSize = (bytes: number) => {
   return `${bytes}B`;
 };
 
+/// How many preview downloads may be in flight at once.
+///
+/// A page is 24 items and they all want their thumbnail at the same moment;
+/// firing every request together makes the first screenful arrive *slower*,
+/// because none of them finish first.
+const PREVIEW_PARALLEL = 6;
+
+let previewsRunning = 0;
+const previewQueue: (() => void)[] = [];
+
+/// Run `task` when a download slot is free.
+const queued = <T,>(task: () => Promise<T>): Promise<T> =>
+  new Promise((resolve, reject) => {
+    const start = () => {
+      previewsRunning += 1;
+      task()
+        .then(resolve, reject)
+        .finally(() => {
+          previewsRunning -= 1;
+          previewQueue.shift()?.();
+        });
+    };
+    if (previewsRunning < PREVIEW_PARALLEL) start();
+    else previewQueue.push(start);
+  });
+
 /// Fetch an item's preview image once, and answer with its local path.
 ///
 /// Hardened the same way the engine's own image fetches are: http(s) only,
@@ -76,23 +102,25 @@ const ensurePreview = async (item: KirieWorkshopItem): Promise<string | null> =>
 
   GLib.mkdir_with_parents(PREVIEW_DIR, 0o755);
   try {
-    await execAsync([
-      "curl",
-      "--silent",
-      "--fail",
-      "--location",
-      "--proto",
-      "=http,https",
-      "--proto-redir",
-      "=http,https",
-      "--max-time",
-      "20",
-      "--max-filesize",
-      "8000000",
-      "--output",
-      path,
-      item.preview,
-    ]);
+    await queued(() =>
+      execAsync([
+        "curl",
+        "--silent",
+        "--fail",
+        "--location",
+        "--proto",
+        "=http,https",
+        "--proto-redir",
+        "=http,https",
+        "--max-time",
+        "20",
+        "--max-filesize",
+        "8000000",
+        "--output",
+        path,
+        item.preview!,
+      ]),
+    );
   } catch (_err) {
     // A missing thumbnail is not worth a notification: the card still says
     // what the item is.

--- a/.config/ags/widgets/WorkshopBrowser.tsx
+++ b/.config/ags/widgets/WorkshopBrowser.tsx
@@ -141,6 +141,18 @@ const FILTER_GROUPS: { label: string; tags: string[] }[] = [
 /// this panel opens over a desktop.
 const ADULT = ["Mature", "Questionable"];
 
+/// One line of readable text from an author-written title.
+///
+/// Workshop titles carry HTML often enough to matter — banners, credit links
+/// — and a card is 148px wide.
+const plainTitle = (raw: string) =>
+  raw
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
 /// Bytes as a short human string.
 const humanSize = (bytes: number) => {
   for (const [unit, scale] of [
@@ -469,7 +481,7 @@ export default function WorkshopBrowser({
         {preview}
         <label
           class="workshop-title"
-          label={item.title}
+          label={plainTitle(item.title) || item.id}
           maxWidthChars={16}
           ellipsize={Pango.EllipsizeMode.END}
           tooltipText={item.title}

--- a/.config/ags/widgets/WorkshopBrowser.tsx
+++ b/.config/ags/widgets/WorkshopBrowser.tsx
@@ -2,6 +2,8 @@ import { createState, With } from "ags";
 import { Gtk } from "ags/gtk4";
 import GLib from "gi://GLib";
 import Pango from "gi://Pango";
+import Gdk from "gi://Gdk";
+import GdkPixbuf from "gi://GdkPixbuf";
 import { execAsync } from "ags/process";
 import { timeout } from "ags/time";
 import { notify } from "../utils/notification";
@@ -30,9 +32,15 @@ import {
 //   process as playing Wallpaper Engine and accrues playtime. This asks the
 //   engine, which already knows.
 
-/// Results per page. Steam serves 50; a grid of 24 previews is what fits on
-/// screen without making the popover a scrolling chore.
-const PAGE_SIZE = 24;
+/// Results per page: three across, four down. Steam serves 50 per query, so a
+/// page here is a slice of one — which keeps every thumbnail on screen at a
+/// size worth looking at.
+const COLUMNS = 3;
+const ROWS = 4;
+const PAGE_SIZE = COLUMNS * ROWS;
+
+/// Thumbnail edge. Steam serves square preview images, so the card is square.
+const TILE = 190;
 
 /// Where downloaded preview thumbnails live.
 const PREVIEW_DIR = `${GLib.get_user_cache_dir()}/ags/workshop-previews`;
@@ -45,8 +53,87 @@ const SORTS: { label: string; value: "popular" | "trend" | "recent" | "rated" }[
     { label: "Top rated", value: "rated" },
   ];
 
-/// Type filters, which are Workshop tags like any other.
-const KINDS = ["Scene", "Video", "Web"];
+/// The Workshop's own filter vocabulary, grouped the way Steam's page groups
+/// it. These are plain tags to the engine — the grouping is purely so the
+/// panel can offer one dropdown per axis instead of a wall of chips.
+///
+/// Tags with spaces in them are why the socket grammar takes quoted values.
+const FILTER_GROUPS: { label: string; tags: string[] }[] = [
+  { label: "Type", tags: ["Scene", "Video", "Web", "Application"] },
+  { label: "Age", tags: ["Everyone", "Questionable", "Mature"] },
+  {
+    label: "Genre",
+    tags: [
+      "Abstract",
+      "Animal",
+      "Anime",
+      "Cartoon",
+      "CGI",
+      "Cyberpunk",
+      "Fantasy",
+      "Game",
+      "Girls",
+      "Guys",
+      "Landscape",
+      "Medieval",
+      "Memes",
+      "MMD",
+      "Music",
+      "Nature",
+      "Pixel art",
+      "Relaxing",
+      "Retro",
+      "Sci-Fi",
+      "Sports",
+      "Technology",
+      "Television",
+      "Vehicle",
+      "Unspecified",
+    ],
+  },
+  {
+    label: "Resolution",
+    tags: [
+      "Standard Definition",
+      "1280 x 720",
+      "1920 x 1080",
+      "2560 x 1440",
+      "3840 x 2160",
+      "Ultrawide Standard",
+      "Ultrawide 2560 x 1080",
+      "Ultrawide 3440 x 1440",
+      "Dual Standard",
+      "Dual 3840 x 1080",
+      "Dual 5120 x 1440",
+      "Triple Standard",
+      "Triple 5760 x 1080",
+      "Triple 7680 x 1440",
+      "Portrait Standard",
+      "Portrait 720 x 1280",
+      "Portrait 1080 x 1920",
+      "Portrait 1440 x 2560",
+      "Portrait 2160 x 3840",
+      "Other resolution",
+      "Dynamic resolution",
+    ],
+  },
+  { label: "Category", tags: ["Wallpaper", "Preset", "Asset"] },
+  {
+    label: "Features",
+    tags: [
+      "Approved",
+      "Audio responsive",
+      "3D",
+      "Customizable",
+      "Puppet Warp",
+      "HDR",
+      "Media Integration",
+      "User Shortcut",
+      "Video Texture",
+      "Asset Pack",
+    ],
+  },
+];
 
 /// Tags that mark adult content. Excluded unless the user says otherwise —
 /// this panel opens over a desktop.
@@ -139,9 +226,21 @@ export default function WorkshopBrowser({
   const [status, setStatus] = createState<string>("");
   const [busy, setBusy] = createState<boolean>(false);
   const [sort, setSort] = createState<(typeof SORTS)[number]["value"]>("popular");
-  const [kind, setKind] = createState<string>("");
+  // One chosen tag per filter group, keyed by group label. Steam ANDs across
+  // groups, which is what a picker wants: Scene + Anime + 2560 x 1440.
+  const [filters, setFilters] = createState<Record<string, string>>({});
   const [allowAdult, setAllowAdult] = createState<boolean>(false);
   const [page, setPage] = createState<number>(1);
+
+  /// Set or clear one group's tag, then search from the first page again: a
+  /// filter change makes the page number meaningless.
+  const setFilter = (group: string, tag: string) => {
+    const next = { ...filters.peek() };
+    if (tag === "" || next[group] === tag) delete next[group];
+    else next[group] = tag;
+    setFilters(next);
+    search(1);
+  };
 
   let query = "";
 
@@ -149,10 +248,16 @@ export default function WorkshopBrowser({
     setBusy(true);
     setPage(nextPage);
     setStatus(nextPage === 1 ? "searching…" : `page ${nextPage}…`);
+    const chosen = Object.values(filters.peek()).filter(Boolean);
     kirieWorkshopSearch({
       text: query,
-      tags: kind.peek() ? [kind.peek()] : [],
-      excludeTags: allowAdult.peek() ? [] : ADULT,
+      tags: chosen,
+      // An explicit age choice wins over the blanket exclusion: asking for
+      // "Mature" and getting nothing would just look broken.
+      excludeTags:
+        allowAdult.peek() || chosen.some((tag) => ADULT.includes(tag))
+          ? []
+          : ADULT,
       sort: sort.peek(),
       page: nextPage,
       limit: PAGE_SIZE,
@@ -229,12 +334,27 @@ export default function WorkshopBrowser({
   const card = (item: KirieWorkshopItem) => {
     const preview = new Gtk.Picture({
       contentFit: Gtk.ContentFit.COVER,
-      widthRequest: 150,
-      heightRequest: 84,
+      widthRequest: TILE,
+      heightRequest: TILE,
       cssClasses: ["workshop-preview"],
     });
     ensurePreview(item).then((path) => {
-      if (path) preview.set_filename(path);
+      if (!path) return;
+      // NOT `set_filename`: that goes through GdkTexture, which decodes only
+      // PNG and JPEG, and a good half of Steam's previews are animated GIFs —
+      // they came out blank. GdkPixbuf reads those (first frame), and scaling
+      // at load keeps a 1080x1080 thumbnail from becoming a 4 MB texture.
+      try {
+        const pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(
+          path,
+          TILE * 2,
+          TILE * 2,
+          true,
+        );
+        preview.set_paintable(Gdk.Texture.new_for_pixbuf(pixbuf));
+      } catch (_err) {
+        // An unreadable thumbnail leaves the placeholder tile.
+      }
     });
 
     // Where this item's files are, once they exist. Set from the search
@@ -313,8 +433,8 @@ export default function WorkshopBrowser({
       class="workshop-browser"
       orientation={Gtk.Orientation.VERTICAL}
       spacing={8}
-      widthRequest={700}
-      heightRequest={520}
+      widthRequest={COLUMNS * (TILE + 26)}
+      heightRequest={ROWS * (TILE + 96)}
     >
       <box spacing={6}>
         {searchEntry}
@@ -337,20 +457,57 @@ export default function WorkshopBrowser({
         </menubutton>
       </box>
 
-      <box spacing={6} class="workshop-filters">
-        {KINDS.map((tag) => (
-          <togglebutton
-            label={tag}
-            active={kind((k) => k === tag)}
-            onToggled={({ active }) => {
-              const next = active ? tag : "";
-              if (kind.peek() === next) return;
-              setKind(next);
-              search(1);
-            }}
-          />
+      <Gtk.FlowBox
+        class="workshop-filters"
+        columnSpacing={6}
+        rowSpacing={6}
+        selectionMode={Gtk.SelectionMode.NONE}
+        homogeneous={false}
+        minChildrenPerLine={3}
+        maxChildrenPerLine={7}
+      >
+        {FILTER_GROUPS.map((group) => (
+          <menubutton class="workshop-filter">
+            {/* The button says what is chosen, not what the group is called:
+                a row of "Type / Age / Genre" tells you nothing about the
+                query you are actually looking at. */}
+            <label
+              label={filters((f) => f[group.label] ?? group.label)}
+              maxWidthChars={16}
+              ellipsize={Pango.EllipsizeMode.END}
+            />
+            <popover position={Gtk.PositionType.BOTTOM}>
+              <scrolledwindow
+                hscrollbarPolicy={Gtk.PolicyType.NEVER}
+                maxContentHeight={360}
+                propagateNaturalHeight
+              >
+                <box orientation={Gtk.Orientation.VERTICAL} class="popover">
+                  <button
+                    class="clear"
+                    label={`Any ${group.label.toLowerCase()}`}
+                    onClicked={(self: Gtk.Button) => {
+                      (self.get_ancestor(Gtk.Popover) as Gtk.Popover)?.popdown();
+                      setFilter(group.label, "");
+                    }}
+                  />
+                  {group.tags.map((tag) => (
+                    <button
+                      class={filters((f) =>
+                        f[group.label] === tag ? "selected" : "",
+                      )}
+                      label={tag}
+                      onClicked={(self: Gtk.Button) => {
+                        (self.get_ancestor(Gtk.Popover) as Gtk.Popover)?.popdown();
+                        setFilter(group.label, tag);
+                      }}
+                    />
+                  ))}
+                </box>
+              </scrolledwindow>
+            </popover>
+          </menubutton>
         ))}
-        <box hexpand />
         <togglebutton
           class="adult"
           label="18+"
@@ -362,7 +519,16 @@ export default function WorkshopBrowser({
             search(1);
           }}
         />
-      </box>
+        <button
+          class="clear-filters"
+          label="Clear"
+          tooltipText="Drop every filter"
+          onClicked={() => {
+            setFilters({});
+            search(1);
+          }}
+        />
+      </Gtk.FlowBox>
 
       <scrolledwindow vexpand hscrollbarPolicy={Gtk.PolicyType.NEVER}>
         <With value={items}>
@@ -372,8 +538,8 @@ export default function WorkshopBrowser({
               rowSpacing={8}
               homogeneous={true}
               selectionMode={Gtk.SelectionMode.NONE}
-              minChildrenPerLine={2}
-              maxChildrenPerLine={4}
+              minChildrenPerLine={COLUMNS}
+              maxChildrenPerLine={COLUMNS}
             >
               {list.map(card)}
             </Gtk.FlowBox>

--- a/.config/ags/widgets/WorkshopBrowser.tsx
+++ b/.config/ags/widgets/WorkshopBrowser.tsx
@@ -36,7 +36,9 @@ import {
 /// page here is a slice of one — which keeps every thumbnail on screen at a
 /// size worth looking at.
 const COLUMNS = 3;
-const ROWS = 4;
+/// Rows *fetched*; the grid scrolls, so this is how much there is to look
+/// through per query rather than how much fits at once.
+const ROWS = 6;
 const PAGE_SIZE = COLUMNS * ROWS;
 
 /// Thumbnail edge. Steam serves square preview images, so the card is square.
@@ -145,13 +147,23 @@ const ADULT = ["Mature", "Questionable"];
 ///
 /// Workshop titles carry HTML often enough to matter — banners, credit links
 /// — and a card is 148px wide.
-const plainTitle = (raw: string) =>
-  raw
-    .replace(/<[^>]*>/g, " ")
-    .replace(/&amp;/gi, "&")
-    .replace(/&nbsp;/gi, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+const plainTitle = (raw: string) => {
+  // Decode before stripping, and repeat: entity-encoded markup would
+  // otherwise be unwrapped into visible tag soup rather than removed.
+  let text = raw;
+  for (let pass = 0; pass < 3; pass += 1) {
+    const next = text
+      .replace(/&nbsp;/gi, " ")
+      .replace(/&lt;/gi, "<")
+      .replace(/&gt;/gi, ">")
+      .replace(/&quot;/gi, '"')
+      .replace(/&amp;/gi, "&")
+      .replace(/<[^>]*>/g, " ");
+    if (next === text) break;
+    text = next;
+  }
+  return text.replace(/\s+/g, " ").trim();
+};
 
 /// Bytes as a short human string.
 const humanSize = (bytes: number) => {
@@ -525,7 +537,9 @@ export default function WorkshopBrowser({
       orientation={Gtk.Orientation.VERTICAL}
       spacing={5}
       widthRequest={COLUMNS * (TILE + 22)}
-      heightRequest={ROWS * (TILE + 62) + 84}
+      // Four rows tall, six rows deep: the panel stays a panel and the extra
+      // two rows are a scroll away.
+      heightRequest={4 * (TILE + 62) + 84}
     >
       <box spacing={4}>
         {searchEntry}

--- a/.config/ags/widgets/WorkshopBrowser.tsx
+++ b/.config/ags/widgets/WorkshopBrowser.tsx
@@ -1,0 +1,373 @@
+import { createState, With } from "ags";
+import { Gtk } from "ags/gtk4";
+import GLib from "gi://GLib";
+import Pango from "gi://Pango";
+import { execAsync } from "ags/process";
+import { timeout } from "ags/time";
+import { notify } from "../utils/notification";
+import {
+  KirieWorkshopItem,
+  kirieWorkshopJob,
+  kirieWorkshopSearch,
+  kirieWorkshopSubscribe,
+  kirieWorkshopSupported,
+} from "../services/kirie";
+
+// Browse the Steam Workshop from the panel.
+//
+// The wallpaper switcher can only offer what is already installed; finding
+// anything new meant leaving for Steam's own UI. kirie answers Workshop
+// queries over its control socket (docs/compat-socket.md §13) by way of a
+// short-lived Steam helper, so this is a view over that: search, filter,
+// subscribe, and apply the moment the files land.
+//
+// Two things it deliberately does not do:
+//
+// * **Ask Steam per keystroke.** A search runs on Enter. Every query is a real
+//   request to Valve, and the engine spawns a helper process for each one.
+// * **Poll Steam for download progress.** The engine follows a subscription by
+//   watching the filesystem, because initialising Steamworks announces the
+//   process as playing Wallpaper Engine and accrues playtime. This asks the
+//   engine, which already knows.
+
+/// Results per page. Steam serves 50; a grid of 24 previews is what fits on
+/// screen without making the popover a scrolling chore.
+const PAGE_SIZE = 24;
+
+/// Where downloaded preview thumbnails live.
+const PREVIEW_DIR = `${GLib.get_user_cache_dir()}/ags/workshop-previews`;
+
+const SORTS: { label: string; value: "popular" | "trend" | "recent" | "rated" }[] =
+  [
+    { label: "Popular", value: "popular" },
+    { label: "Trending", value: "trend" },
+    { label: "Newest", value: "recent" },
+    { label: "Top rated", value: "rated" },
+  ];
+
+/// Type filters, which are Workshop tags like any other.
+const KINDS = ["Scene", "Video", "Web"];
+
+/// Tags that mark adult content. Excluded unless the user says otherwise —
+/// this panel opens over a desktop.
+const ADULT = ["Mature", "Questionable"];
+
+/// Bytes as a short human string.
+const humanSize = (bytes: number) => {
+  for (const [unit, scale] of [
+    ["G", 1024 ** 3],
+    ["M", 1024 ** 2],
+    ["K", 1024],
+  ] as const) {
+    if (bytes >= scale) return `${(bytes / scale).toFixed(1)}${unit}`;
+  }
+  return `${bytes}B`;
+};
+
+/// Fetch an item's preview image once, and answer with its local path.
+///
+/// Hardened the same way the engine's own image fetches are: http(s) only,
+/// including across redirects, with a time and a size cap, because the URL
+/// comes from the network and the file lands on disk.
+const ensurePreview = async (item: KirieWorkshopItem): Promise<string | null> => {
+  if (!item.preview) return null;
+  const path = `${PREVIEW_DIR}/${item.id}.img`;
+  if (GLib.file_test(path, GLib.FileTest.EXISTS)) return path;
+
+  GLib.mkdir_with_parents(PREVIEW_DIR, 0o755);
+  try {
+    await execAsync([
+      "curl",
+      "--silent",
+      "--fail",
+      "--location",
+      "--proto",
+      "=http,https",
+      "--proto-redir",
+      "=http,https",
+      "--max-time",
+      "20",
+      "--max-filesize",
+      "8000000",
+      "--output",
+      path,
+      item.preview,
+    ]);
+  } catch (_err) {
+    // A missing thumbnail is not worth a notification: the card still says
+    // what the item is.
+    return null;
+  }
+  return GLib.file_test(path, GLib.FileTest.EXISTS) ? path : null;
+};
+
+export default function WorkshopBrowser({
+  onApply,
+}: {
+  /// Show an installed item. The caller owns which screen and slot that means.
+  onApply: (dir: string) => void;
+}) {
+  const [items, setItems] = createState<KirieWorkshopItem[]>([]);
+  const [status, setStatus] = createState<string>("");
+  const [busy, setBusy] = createState<boolean>(false);
+  const [sort, setSort] = createState<(typeof SORTS)[number]["value"]>("popular");
+  const [kind, setKind] = createState<string>("");
+  const [allowAdult, setAllowAdult] = createState<boolean>(false);
+  const [page, setPage] = createState<number>(1);
+
+  let query = "";
+
+  const search = (nextPage = 1) => {
+    setBusy(true);
+    setPage(nextPage);
+    setStatus(nextPage === 1 ? "searching…" : `page ${nextPage}…`);
+    kirieWorkshopSearch({
+      text: query,
+      tags: kind.peek() ? [kind.peek()] : [],
+      excludeTags: allowAdult.peek() ? [] : ADULT,
+      sort: sort.peek(),
+      page: nextPage,
+      limit: PAGE_SIZE,
+    })
+      .then((found) => {
+        setItems(found);
+        setStatus(
+          found.length === 0
+            ? "nothing matched"
+            : `${found.length} result(s) — page ${nextPage}`,
+        );
+      })
+      .catch((err) => {
+        setItems([]);
+        setStatus(String(err).replace(/^Error:\s*/, ""));
+      })
+      .finally(() => setBusy(false));
+  };
+
+  /// Follow a subscription to its end, reporting into the card's own button.
+  ///
+  /// `ready` is how the card remembers where the files landed: the button keeps
+  /// one click handler that branches on it, rather than growing a second one
+  /// that would re-subscribe on every press.
+  const follow = (
+    job: number,
+    button: Gtk.Button,
+    item: KirieWorkshopItem,
+    ready: (dir: string) => void,
+  ) => {
+    kirieWorkshopJob(job)
+      .then((state) => {
+        switch (state.state) {
+          case "installed":
+            button.label = "Apply";
+            button.set_css_classes(["subscribe", "ready"]);
+            if (state.dir) ready(state.dir);
+            setStatus(`${item.title} installed`);
+            return;
+          case "error":
+            button.label = "Failed";
+            setStatus(state.error ?? "the download failed");
+            return;
+          default:
+            button.label = state.bytes
+              ? `${humanSize(state.bytes)}…`
+              : "Waiting…";
+            timeout(1000, () => follow(job, button, item, ready));
+        }
+      })
+      .catch((err) => {
+        button.label = "Failed";
+        setStatus(String(err));
+      });
+  };
+
+  const searchEntry = (
+    <entry
+      hexpand
+      maxWidthChars={1}
+      placeholderText="Search the Workshop…"
+      $={(self: Gtk.Entry) =>
+        self.connect("changed", () => {
+          query = self.text;
+        })
+      }
+      onActivate={(self: Gtk.Entry) => {
+        query = self.text;
+        search(1);
+      }}
+    />
+  ) as Gtk.Entry;
+
+  const card = (item: KirieWorkshopItem) => {
+    const preview = new Gtk.Picture({
+      contentFit: Gtk.ContentFit.COVER,
+      widthRequest: 150,
+      heightRequest: 84,
+      cssClasses: ["workshop-preview"],
+    });
+    ensurePreview(item).then((path) => {
+      if (path) preview.set_filename(path);
+    });
+
+    // Where this item's files are, once they exist. Set from the search
+    // result for an item already installed, and from the job that fetches it.
+    let installedDir: string | null = item.installed ? item.dir : null;
+
+    const action = (
+      <button
+        class={installedDir ? "subscribe ready" : "subscribe"}
+        label={installedDir ? "Apply" : item.subscribed ? "Waiting…" : "Get"}
+        onClicked={(self: Gtk.Button) => {
+          if (installedDir) {
+            onApply(installedDir);
+            return;
+          }
+          self.label = "Subscribing…";
+          kirieWorkshopSubscribe(item.id)
+            .then((job) =>
+              follow(job, self, item, (dir) => {
+                installedDir = dir;
+              }),
+            )
+            .catch((err) => {
+              self.label = "Get";
+              notify({ summary: "Workshop", body: String(err) });
+            });
+        }}
+      />
+    ) as Gtk.Button;
+
+    return (
+      <box class="workshop-card" orientation={Gtk.Orientation.VERTICAL} spacing={4}>
+        {preview}
+        <label
+          class="workshop-title"
+          label={item.title}
+          maxWidthChars={18}
+          ellipsize={Pango.EllipsizeMode.END}
+          tooltipText={item.title}
+        />
+        <box spacing={6} halign={Gtk.Align.CENTER}>
+          <label class="workshop-kind" label={item.type} />
+          <label
+            class="workshop-meta"
+            label={`${Math.round((item.score ?? 0) * 100)}% · ${humanSize(item.size ?? 0)}`}
+          />
+        </box>
+        {/* Steam knows what the item is; kirie knows whether this build can
+            render it, which is the part worth saying before installing. */}
+        {!item.renderable && (
+          <label
+            class="workshop-warning"
+            label="kirie cannot render this"
+            tooltipText={item.reason ?? ""}
+          />
+        )}
+        {action}
+      </box>
+    );
+  };
+
+  // Say up front when the engine is too old for any of this, rather than
+  // letting every search fail with "unknown command".
+  kirieWorkshopSupported().then((supported) => {
+    if (supported) {
+      search(1);
+    } else {
+      setStatus(
+        "this engine has no Workshop support — update kirie (kirie workshop search)",
+      );
+    }
+  });
+
+  return (
+    <box
+      class="workshop-browser"
+      orientation={Gtk.Orientation.VERTICAL}
+      spacing={8}
+      widthRequest={700}
+      heightRequest={520}
+    >
+      <box spacing={6}>
+        {searchEntry}
+        <menubutton class="workshop-sort">
+          <label label={sort((s) => SORTS.find((o) => o.value === s)!.label)} />
+          <popover position={Gtk.PositionType.BOTTOM}>
+            <box orientation={Gtk.Orientation.VERTICAL} class="popover">
+              {SORTS.map((option) => (
+                <button
+                  label={option.label}
+                  onClicked={(self: Gtk.Button) => {
+                    setSort(option.value);
+                    (self.get_ancestor(Gtk.Popover) as Gtk.Popover)?.popdown();
+                    search(1);
+                  }}
+                />
+              ))}
+            </box>
+          </popover>
+        </menubutton>
+      </box>
+
+      <box spacing={6} class="workshop-filters">
+        {KINDS.map((tag) => (
+          <togglebutton
+            label={tag}
+            active={kind((k) => k === tag)}
+            onToggled={({ active }) => {
+              const next = active ? tag : "";
+              if (kind.peek() === next) return;
+              setKind(next);
+              search(1);
+            }}
+          />
+        ))}
+        <box hexpand />
+        <togglebutton
+          class="adult"
+          label="18+"
+          tooltipText="Include Mature and Questionable items"
+          active={allowAdult((a) => a)}
+          onToggled={({ active }) => {
+            if (allowAdult.peek() === active) return;
+            setAllowAdult(active);
+            search(1);
+          }}
+        />
+      </box>
+
+      <scrolledwindow vexpand hscrollbarPolicy={Gtk.PolicyType.NEVER}>
+        <With value={items}>
+          {(list) => (
+            <Gtk.FlowBox
+              columnSpacing={8}
+              rowSpacing={8}
+              homogeneous={true}
+              selectionMode={Gtk.SelectionMode.NONE}
+              minChildrenPerLine={2}
+              maxChildrenPerLine={4}
+            >
+              {list.map(card)}
+            </Gtk.FlowBox>
+          )}
+        </With>
+      </scrolledwindow>
+
+      <box spacing={8}>
+        <label class="workshop-status" hexpand xalign={0} label={status((s) => s)} />
+        <button
+          label="‹"
+          tooltipText="Previous page"
+          sensitive={page((p) => p > 1)}
+          onClicked={() => search(Math.max(1, page.peek() - 1))}
+        />
+        <button
+          label="›"
+          tooltipText="Next page"
+          sensitive={busy((b) => !b)}
+          onClicked={() => search(page.peek() + 1)}
+        />
+      </box>
+    </box>
+  );
+}

--- a/.config/ags/widgets/WorkshopBrowser.tsx
+++ b/.config/ags/widgets/WorkshopBrowser.tsx
@@ -15,22 +15,12 @@ import {
   kirieWorkshopSupported,
 } from "../services/kirie";
 
-// Browse the Steam Workshop from the panel.
+// Browse the Steam Workshop over kirie's control socket
+// (docs/compat-socket.md §13): search, filter, subscribe, apply.
 //
-// The wallpaper switcher can only offer what is already installed; finding
-// anything new meant leaving for Steam's own UI. kirie answers Workshop
-// queries over its control socket (docs/compat-socket.md §13) by way of a
-// short-lived Steam helper, so this is a view over that: search, filter,
-// subscribe, and apply the moment the files land.
-//
-// Two things it deliberately does not do:
-//
-// * **Ask Steam per keystroke.** A search runs on Enter. Every query is a real
-//   request to Valve, and the engine spawns a helper process for each one.
-// * **Poll Steam for download progress.** The engine follows a subscription by
-//   watching the filesystem, because initialising Steamworks announces the
-//   process as playing Wallpaper Engine and accrues playtime. This asks the
-//   engine, which already knows.
+// Searches run on Enter, never per keystroke — every query is a real request
+// to Valve. Download progress comes from the engine, which watches the
+// filesystem, not from Steam.
 
 /// Results per page: three across, four down. Steam serves 50 per query, so a
 /// page here is a slice of one — which keeps every thumbnail on screen at a
@@ -57,11 +47,8 @@ const SORTS: { label: string; value: "popular" | "trend" | "recent" | "rated" }[
     { label: "Top rated", value: "rated" },
   ];
 
-/// The Workshop's own filter vocabulary, grouped the way Steam's page groups
-/// it. These are plain tags to the engine — the grouping is purely so the
-/// panel can offer one dropdown per axis instead of a wall of chips.
-///
-/// Tags with spaces in them are why the socket grammar takes quoted values.
+/// The Workshop's filter vocabulary. Plain tags to the engine; grouped here
+/// only so the panel can offer one dropdown per axis.
 const FILTER_GROUPS: { label: string; tags: string[] }[] = [
   { label: "Type", tags: ["Scene", "Video", "Web", "Application"] },
   { label: "Age", tags: ["Everyone", "Questionable", "Mature"] },
@@ -177,11 +164,8 @@ const humanSize = (bytes: number) => {
   return `${bytes}B`;
 };
 
-/// How many preview downloads may be in flight at once.
-///
-/// A page is 24 items and they all want their thumbnail at the same moment;
-/// firing every request together makes the first screenful arrive *slower*,
-/// because none of them finish first.
+/// Preview downloads in flight at once. Firing all 18 together makes the
+/// first screenful arrive slower, because none of them finish first.
 const PREVIEW_PARALLEL = 6;
 
 let previewsRunning = 0;
@@ -203,11 +187,8 @@ const queued = <T,>(task: () => Promise<T>): Promise<T> =>
     else previewQueue.push(start);
   });
 
-/// Fetch an item's preview image once, and answer with its local path.
-///
-/// Hardened the same way the engine's own image fetches are: http(s) only,
-/// including across redirects, with a time and a size cap, because the URL
-/// comes from the network and the file lands on disk.
+/// Fetch an item's preview image once, and answer with its local path. The
+/// URL comes off the network, so curl is held to http(s), a time and a size.
 const ensurePreview = async (item: KirieWorkshopItem): Promise<string | null> => {
   if (!item.preview) return null;
   const path = `${PREVIEW_DIR}/${item.id}.img`;
@@ -312,10 +293,8 @@ export default function WorkshopBrowser({
   };
 
   /// Follow a subscription to its end, reporting into the card's own button.
-  ///
-  /// `ready` is how the card remembers where the files landed: the button keeps
-  /// one click handler that branches on it, rather than growing a second one
-  /// that would re-subscribe on every press.
+  /// `ready` records where the files landed, so the single click handler can
+  /// branch instead of a second one being added that re-subscribes.
   const follow = (
     job: number,
     button: Gtk.Button,

--- a/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
+++ b/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
@@ -1088,6 +1088,23 @@ export default () => {
             keyChanged="autoWorkspaceSwitching"
             setting={globalSettings.peek().autoWorkspaceSwitching}
           /> */}
+            <Setting
+              keyChanged="wallpaper.mode"
+              setting={globalSettings.peek().wallpaper.mode}
+              choices={[
+                { label: "Per Workspace", value: "workspace" },
+                { label: "Global", value: "global" },
+              ]}
+              callBack={(mode) =>
+                execAsync([
+                  "bash",
+                  "-c",
+                  `$HOME/.config/hypr/wallpaper-daemon/set-wallpaper.sh --mode ${mode}`,
+                ]).catch((err) =>
+                  notify({ summary: "Error", body: String(err) }),
+                )
+              }
+            />
             <FileManagerSelector />
           </box>
         </box>

--- a/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
+++ b/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
@@ -27,6 +27,7 @@ import {
 import { WidgetSelector } from "../../../interfaces/widgetSelector.interface";
 import { refreshCss } from "../../../utils/scss";
 import { timeout } from "ags/time";
+import GLib from "gi://GLib";
 import { hyprThemeConfPath } from "../../../constants/path.constants";
 import {
   kirieCheck,
@@ -782,6 +783,38 @@ const kirieCommand = (key: string, value: any): string | null => {
   }
 };
 
+/// Settings the engine can only be told at launch.
+///
+/// The control socket has no verb for these — audio reactivity, particles,
+/// which GPU, which layer — so changing one used to set the value and do
+/// nothing at all, which reads as the toggle being broken. `kirie.sh` already
+/// builds the command line from this same settings file, so the honest way to
+/// apply them is to relaunch the engine with it.
+const LAUNCH_ONLY = new Set([
+  "noAudioProcessing",
+  "disableParticles",
+  "fullscreenPauseOnlyActive",
+  "layer",
+  "gpu",
+  "assetsDir",
+]);
+
+/// Debounce generation, so flipping three of these in a row restarts once.
+let restartGeneration = 0;
+
+const restartEngineSoon = () => {
+  restartGeneration += 1;
+  const mine = restartGeneration;
+  timeout(600, () => {
+    if (mine !== restartGeneration) return;
+    execAsync([
+      "bash",
+      `${GLib.get_home_dir()}/.config/hypr/wallpaper-daemon/kirie.sh`,
+      "--restart",
+    ]).catch((err) => notify({ summary: "Wallpaper Engine", body: String(err) }));
+  });
+};
+
 const applyEngineSetting = (key: string, value: any) => {
   // Scaling and edge handling are per screen in the engine; the panel keeps
   // one value and applies it to every monitor.
@@ -793,7 +826,11 @@ const applyEngineSetting = (key: string, value: any) => {
   }
 
   const command = kirieCommand(key, value);
-  if (command) kirieOk(command);
+  if (command) {
+    kirieOk(command);
+    return;
+  }
+  if (LAUNCH_ONLY.has(key)) restartEngineSoon();
 };
 
 const EngineSetting = ({

--- a/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
+++ b/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
@@ -237,8 +237,16 @@ const BarLayoutSetting = () => {
         label={"bar Layout"}
         halign={Gtk.Align.START}
       />
-      <box class="setting" spacing={10}>
-        <For each={globalSettings(({ bar }) => bar.layout)}>
+      {/* One button per bar widget, and they are drag-reordered, so they have
+          to stay on one line — which would otherwise make this row alone
+          decide the panel's width. It scrolls by itself instead. */}
+      <scrolledwindow
+        hscrollbarPolicy={Gtk.PolicyType.AUTOMATIC}
+        vscrollbarPolicy={Gtk.PolicyType.NEVER}
+        propagateNaturalWidth={false}
+      >
+        <box class="setting" spacing={10}>
+          <For each={globalSettings(({ bar }) => bar.layout)}>
           {(widget: WidgetSelector) => {
             return (
               <togglebutton
@@ -338,8 +346,9 @@ const BarLayoutSetting = () => {
               ></togglebutton>
             );
           }}
-        </For>
-      </box>
+          </For>
+        </box>
+      </scrolledwindow>
     </box>
   );
 };
@@ -355,7 +364,12 @@ const Setting = ({
   callBack?: (newValue?: any) => void;
   choices?: { label: string; value: any }[];
 }) => {
-  const Title = () => <label hexpand xalign={0} label={setting.name} />;
+  // `wrap` is what lets the label shrink: a wrapped label only ever demands
+  // room for its longest word, where a single-line one demands the whole
+  // sentence — and the panel is only as wide as its widest child.
+  const Title = () => (
+    <label hexpand xalign={0} wrap={true} label={setting.name} />
+  );
 
   const SliderWidget = () => {
     const infoLabel = (
@@ -371,7 +385,9 @@ const Setting = ({
 
     const Slider = (
       <slider
-        widthRequest={globalSettings(({ leftPanel }) => leftPanel.width / 3)}
+        // A minimum, not a preference: paired with a long setting name it was
+        // enough on its own to push a row past the panel's width.
+        widthRequest={globalSettings(({ leftPanel }) => leftPanel.width / 4)}
         class="slider"
         drawValue={false}
         min={setting.min}
@@ -442,7 +458,17 @@ const Setting = ({
     return (
       <box orientation={Gtk.Orientation.VERTICAL} spacing={10}>
         <Title />
-        <box spacing={5}>
+        {/* A row of choices used to decide how wide the whole panel was: an
+            audio picker with eight devices made every other setting scroll
+            sideways. A FlowBox wraps onto a second line instead. */}
+        <Gtk.FlowBox
+          columnSpacing={5}
+          rowSpacing={5}
+          selectionMode={Gtk.SelectionMode.NONE}
+          homogeneous={true}
+          minChildrenPerLine={1}
+          maxChildrenPerLine={4}
+        >
           {choices &&
             choices.map((choice) => (
               <togglebutton
@@ -475,7 +501,7 @@ const Setting = ({
                 }}
               />
             ))}
-        </box>
+        </Gtk.FlowBox>
       </box>
     );
   };
@@ -495,6 +521,11 @@ const Setting = ({
         <box orientation={Gtk.Orientation.HORIZONTAL} spacing={5} hexpand>
           <entry
             hexpand
+            // Without this an entry asks for room for its whole value, and a
+            // 40-character API key made the entire settings panel wider than
+            // the panel it lives in.
+            maxWidthChars={1}
+            widthChars={1}
             text={setting.value ?? ""}
             placeholderText={`Enter ${setting.name}`}
             // For GTK4/AGS, passing the Boolean binding correctly is important
@@ -858,6 +889,10 @@ export default () => {
     <box class="settings" orientation={Gtk.Orientation.VERTICAL} spacing={5}>
       <scrolledwindow
         vexpand
+        // The panel has a fixed width, so anything wider than it is a bug in
+        // the row rather than something to scroll to: settings that cannot
+        // fit shrink instead.
+        hscrollbarPolicy={Gtk.PolicyType.NEVER}
         $={() => {
           // Initialize detection
           detectFileManagers();

--- a/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
+++ b/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
@@ -34,6 +34,7 @@ import {
   kirieGpus,
   kirieInstalled,
   kirieOk,
+  kirieWallpaperEngineInstalled,
 } from "../../../services/kirie";
 const hyprland = Hyprland.get_default();
 
@@ -815,6 +816,9 @@ const restartEngineSoon = () => {
   });
 };
 
+const [weInstalled, setWeInstalled] = createState<boolean>(false);
+kirieWallpaperEngineInstalled().then(setWeInstalled);
+
 const applyEngineSetting = (key: string, value: any) => {
   // Scaling and edge handling are per screen in the engine; the panel keeps
   // one value and applies it to every monitor.
@@ -1093,7 +1097,9 @@ export default () => {
               ]}
             />
           </box>
-          {kirieInstalled() && (
+          {/* Same gate as the switcher's engine controls: kirie without
+              Wallpaper Engine's assets has nothing to apply these to. */}
+          {weInstalled.get() && (
             <box
               class={"category"}
               orientation={Gtk.Orientation.VERTICAL}

--- a/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
+++ b/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
@@ -4,7 +4,14 @@ import { Gdk } from "ags/gtk4";
 import { Astal } from "ags/gtk4";
 import Hyprland from "gi://AstalHyprland";
 import GObject from "ags/gobject";
-import { createBinding, createState, createComputed, Accessor, For } from "ags";
+import {
+  createBinding,
+  createState,
+  createComputed,
+  Accessor,
+  For,
+  With,
+} from "ags";
 import { execAsync } from "ags/process";
 import { notify } from "../../../utils/notification";
 import { AGSSetting } from "../../../interfaces/settings.interface";
@@ -21,6 +28,12 @@ import { WidgetSelector } from "../../../interfaces/widgetSelector.interface";
 import { refreshCss } from "../../../utils/scss";
 import { timeout } from "ags/time";
 import { hyprThemeConfPath } from "../../../constants/path.constants";
+import {
+  kirieCheck,
+  kirieGpus,
+  kirieInstalled,
+  kirieOk,
+} from "../../../services/kirie";
 const hyprland = Hyprland.get_default();
 
 const hyprCustomDir: string = "$HOME/.config/hypr/config/custom";
@@ -625,6 +638,181 @@ const applyHyprlandSetting = (fullKey: string, value: any) => {
   ]).catch((err) => notify(err));
 };
 
+// Wallpaper Engine (kirie) --------------------------------------------------
+//
+// The engine takes most of these live over its control socket; the few it can
+// only read at startup are handed to the next launch by the wallpaper daemon,
+// which reads them straight out of this settings file.
+
+const kirieScript = "$HOME/.config/hypr/wallpaper-daemon/kirie.sh";
+
+type Choice = { label: string; value: any };
+
+const scalingChoices: Choice[] = [
+  { label: "Default", value: "default" },
+  { label: "Stretch", value: "stretch" },
+  { label: "Fit", value: "fit" },
+  { label: "Fill", value: "fill" },
+];
+
+const clampChoices: Choice[] = [
+  { label: "Clamp", value: "clamp" },
+  { label: "Border", value: "border" },
+  { label: "Repeat", value: "repeat" },
+];
+
+const layerChoices: Choice[] = [
+  { label: "Background", value: "background" },
+  { label: "Bottom", value: "bottom" },
+  { label: "Top", value: "top" },
+  { label: "Overlay", value: "overlay" },
+];
+
+const [gpuChoices, setGpuChoices] = createState<Choice[]>([
+  { label: "Automatic", value: "auto" },
+]);
+const [audioChoices, setAudioChoices] = createState<Choice[]>([
+  { label: "Default", value: "" },
+]);
+
+// Both lists describe the machine, not the config, so they are read from the
+// machine: kirie knows the GPUs it can be pinned to, PipeWire knows the
+// sources a wallpaper can listen to.
+const detectEngineChoices = () => {
+  if (!kirieInstalled()) return;
+
+  // The reported names are long enough to stretch the whole panel
+  // ("AMD Ryzen 9 7950X 16-Core Processor (RADV RAPHAEL_MENDOCINO)"), and the
+  // vendor plus the kind is what picks a GPU anyway.
+  kirieGpus()
+    .then((gpus) =>
+      setGpuChoices(
+        gpus.map((gpu) => ({
+          label:
+            gpu.value === "auto"
+              ? "Automatic"
+              : `${gpu.value.toUpperCase()} (${gpu.kind})`,
+          value: gpu.value,
+        })),
+      ),
+    )
+    .catch(() => {});
+
+  execAsync(["bash", "-c", "pactl -f json list sources"])
+    .then((output) => {
+      const sources = JSON.parse(output) as {
+        name: string;
+        description: string;
+      }[];
+      setAudioChoices([
+        { label: "Default", value: "" },
+        // Wallpapers react to what is being played, which is what a monitor
+        // source carries.
+        ...sources
+          .filter((source) => source.name.endsWith(".monitor"))
+          .map((source) => ({
+            label: (source.description || source.name)
+              .replace(/^Monitor of /, "")
+              .slice(0, 16),
+            value: source.name,
+          })),
+      ]);
+    })
+    .catch(() => {});
+};
+
+/** The socket command for a setting the running engine can take live. */
+const kirieCommand = (key: string, value: any): string | null => {
+  switch (key) {
+    case "fps":
+      return `set fps ${Math.round(value)}`;
+    case "batteryFps":
+      return `set batteryfps ${Math.round(value)}`;
+    case "renderScale":
+      return `set renderscale ${value}`;
+    case "playbackSpeed":
+      return `speed ${value}`;
+    case "volume":
+      return `volume ${Math.round(value)}`;
+    case "mute":
+      return `mute ${value ? 1 : 0}`;
+    case "audioDevice":
+      return value ? `set audiodevice ${value}` : null;
+    case "noAutomute":
+      return `set noautomute ${value}`;
+    case "disableMouse":
+      return `set disablemouse ${value}`;
+    case "disableParallax":
+      return `set disableparallax ${value}`;
+    case "noFullscreenPause":
+      return `set nofullscreenpause ${value}`;
+    default:
+      return null;
+  }
+};
+
+const applyEngineSetting = (key: string, value: any) => {
+  // Scaling and edge handling are per screen in the engine; the panel keeps
+  // one value and applies it to every monitor.
+  if (key === "scaling" || key === "clamp") {
+    hyprland
+      .get_monitors()
+      .forEach((monitor) => kirieOk(`${key} ${monitor.get_name()} ${value}`));
+    return;
+  }
+
+  const command = kirieCommand(key, value);
+  if (command) kirieOk(command);
+};
+
+const EngineSetting = ({
+  setting,
+  choices,
+}: {
+  setting: string;
+  choices?: Choice[];
+}) => (
+  <Setting
+    keyChanged={`wallpaperEngine.${setting}`}
+    setting={(globalSettings.peek().wallpaperEngine as any)[setting]}
+    choices={choices}
+    callBack={(value) => applyEngineSetting(setting, value)}
+  />
+);
+
+const EngineActions = () => {
+  const run = (args: string, summary: string) =>
+    execAsync(["bash", "-c", `${kirieScript} ${args}`])
+      .then(() => notify({ summary: "Wallpaper Engine", body: summary }))
+      .catch((err) => notify({ summary: "Error", body: String(err) }));
+
+  return (
+    <box spacing={5} homogeneous>
+      <button
+        label="Restart Engine"
+        tooltipText="Apply the settings that are only read at startup"
+        onClicked={() => run("--restart", "Engine restarted.")}
+      />
+      <button
+        label="Stop Engine"
+        tooltipText="Stop rendering until a Wallpaper Engine wallpaper is picked again"
+        onClicked={() => run("--stop", "Engine stopped.")}
+      />
+      <button
+        label="Diagnostics"
+        tooltipText="Check what the engine needs to render on this machine"
+        onClicked={() =>
+          kirieCheck()
+            .then((out) => notify({ summary: "kirie check", body: out.trim() }))
+            .catch((err) =>
+              notify({ summary: "kirie check", body: String(err).trim() }),
+            )
+        }
+      />
+    </box>
+  );
+};
+
 const createHyprlandSettings = (
   prefix: string,
   settings: NestedSettings,
@@ -670,10 +858,11 @@ export default () => {
     <box class="settings" orientation={Gtk.Orientation.VERTICAL} spacing={5}>
       <scrolledwindow
         vexpand
-        $={() =>
+        $={() => {
           // Initialize detection
-          detectFileManagers()
-        }
+          detectFileManagers();
+          detectEngineChoices();
+        }}
       >
         <box orientation={Gtk.Orientation.VERTICAL} spacing={16}>
           <box
@@ -832,6 +1021,41 @@ export default () => {
               ]}
             />
           </box>
+          {kirieInstalled() && (
+            <box
+              class={"category"}
+              orientation={Gtk.Orientation.VERTICAL}
+              spacing={16}
+            >
+              <label label="Wallpaper Engine" halign={Gtk.Align.START} />
+              <EngineSetting setting="fps" />
+              <EngineSetting setting="batteryFps" />
+              <EngineSetting setting="renderScale" />
+              <EngineSetting setting="playbackSpeed" />
+              <EngineSetting setting="volume" />
+              <EngineSetting setting="mute" />
+              <With value={audioChoices}>
+                {(choices) => (
+                  <EngineSetting setting="audioDevice" choices={choices} />
+                )}
+              </With>
+              <EngineSetting setting="noAutomute" />
+              <EngineSetting setting="noAudioProcessing" />
+              <EngineSetting setting="scaling" choices={scalingChoices} />
+              <EngineSetting setting="clamp" choices={clampChoices} />
+              <EngineSetting setting="layer" choices={layerChoices} />
+              <With value={gpuChoices}>
+                {(choices) => <EngineSetting setting="gpu" choices={choices} />}
+              </With>
+              <EngineSetting setting="assetsDir" />
+              <EngineSetting setting="disableMouse" />
+              <EngineSetting setting="disableParallax" />
+              <EngineSetting setting="disableParticles" />
+              <EngineSetting setting="noFullscreenPause" />
+              <EngineSetting setting="fullscreenPauseOnlyActive" />
+              <EngineActions />
+            </box>
+          )}
           <box
             class={"category"}
             orientation={Gtk.Orientation.VERTICAL}

--- a/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
+++ b/.config/ags/widgets/leftPanel/components/SettingsWidget.tsx
@@ -1098,12 +1098,15 @@ export default () => {
             />
           </box>
           {/* Same gate as the switcher's engine controls: kirie without
-              Wallpaper Engine's assets has nothing to apply these to. */}
-          {weInstalled.get() && (
+              Wallpaper Engine's assets has nothing to apply these to. Bound
+              rather than read once — the check is async, so a plain read is
+              always false at render and the section never appears. */}
+          {(
             <box
               class={"category"}
               orientation={Gtk.Orientation.VERTICAL}
               spacing={16}
+              visible={weInstalled((installed) => installed)}
             >
               <label label="Wallpaper Engine" halign={Gtk.Align.START} />
               <EngineSetting setting="fps" />

--- a/.config/hypr/config/env.lua
+++ b/.config/hypr/config/env.lua
@@ -1,1 +1,18 @@
 hl.env("HYPRCURSOR_SIZE", "24")
+
+-- With the display cable on the RTX 4080, aquamarine must take that card as
+-- the PRIMARY device: the first entry is what Hyprland renders on, the rest
+-- are kept open so their outputs still work. Listing the iGPU second means a
+-- monitor plugged into the motherboard keeps lighting up, and the iGPU stays
+-- available as a render device for anything that asks for it.
+--
+-- By-path, not /dev/dri/cardN: the numbering is discovery order and can swap
+-- between boots, which would silently make the wrong card primary.
+--
+-- (Until the cable actually moves, this makes Hyprland render on the 4080 and
+-- scan out through the iGPU — the reverse of what is wanted, and the exact
+-- cross-GPU path whose fence loss has been crashing the session. Comment
+-- these three lines out to go back.)
+hl.env("AQ_DRM_DEVICES", "/dev/dri/by-path/pci-0000:01:00.0-card:/dev/dri/by-path/pci-0000:11:00.0-card")
+hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
+hl.env("GBM_BACKEND", "nvidia-drm")

--- a/.config/hypr/config/env.lua
+++ b/.config/hypr/config/env.lua
@@ -1,18 +1,1 @@
 hl.env("HYPRCURSOR_SIZE", "24")
-
--- With the display cable on the RTX 4080, aquamarine must take that card as
--- the PRIMARY device: the first entry is what Hyprland renders on, the rest
--- are kept open so their outputs still work. Listing the iGPU second means a
--- monitor plugged into the motherboard keeps lighting up, and the iGPU stays
--- available as a render device for anything that asks for it.
---
--- By-path, not /dev/dri/cardN: the numbering is discovery order and can swap
--- between boots, which would silently make the wrong card primary.
---
--- (Until the cable actually moves, this makes Hyprland render on the 4080 and
--- scan out through the iGPU — the reverse of what is wanted, and the exact
--- cross-GPU path whose fence loss has been crashing the session. Comment
--- these three lines out to go back.)
-hl.env("AQ_DRM_DEVICES", "/dev/dri/by-path/pci-0000:01:00.0-card:/dev/dri/by-path/pci-0000:11:00.0-card")
-hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
-hl.env("GBM_BACKEND", "nvidia-drm")

--- a/.config/hypr/config/windowrule.lua
+++ b/.config/hypr/config/windowrule.lua
@@ -107,3 +107,12 @@ hl.window_rule({
     match = { class = "^(grass)" },
     workspace = "9 silent",
 })
+
+-- File pickers opened from the panel have no parent window to sit on, so
+-- tiling them drops a chooser into a workspace slot beside real windows.
+hl.window_rule({
+    match = { class = "^(zenity|xdg-desktop-portal-gtk)$" },
+    float = true,
+    center = true,
+    size = { 900, 600 },
+})

--- a/.config/hypr/maintenance/components/essentials.py
+++ b/.config/hypr/maintenance/components/essentials.py
@@ -29,11 +29,8 @@ class Colors:
 
 def install_core_tools() -> None:
     packages_to_install: list[str] = []
-    # No lolcat here. The repo one is ruby's, which drags in ruby, rubygems and
-    # rdoc for a banner — and the package list installs `c-lolcat` later, which
-    # *conflicts* with it, so the install stopped to ask permission to remove
-    # what it had just put on. The banners already tolerate it being absent
-    # (every call is check=False), and c-lolcat provides the same command.
+    # No lolcat: the package list installs c-lolcat, which conflicts with the
+    # repo's ruby one. Banners already tolerate it missing (check=False).
     packages_names = ["git", "fzf", "figlet"]
 
     print("Checking core tools installation...")
@@ -47,11 +44,8 @@ def install_core_tools() -> None:
 
     if packages_to_install:
         print(f"Installing: {' '.join(packages_to_install)}")
-        # -Syu, not -S: a machine whose package database is older than the
-        # mirrors asks for versions that have already been superseded and
-        # removed, and every mirror answers 404 — which is how the very first
-        # step of a fresh install failed. Refreshing without upgrading (-Sy)
-        # would leave a partial upgrade behind instead, so it is the full one.
+        # -Syu: a stale database asks for versions the mirrors have already
+        # replaced and every one answers 404. -Sy alone risks a partial upgrade.
         run_cmd(
             ["sudo", "pacman", "-Syu", "--needed", "--noconfirm", *packages_to_install]
         )

--- a/.config/hypr/maintenance/components/essentials.py
+++ b/.config/hypr/maintenance/components/essentials.py
@@ -42,7 +42,14 @@ def install_core_tools() -> None:
 
     if packages_to_install:
         print(f"Installing: {' '.join(packages_to_install)}")
-        run_cmd(["sudo", "pacman", "-S", "--noconfirm", *packages_to_install])
+        # -Syu, not -S: a machine whose package database is older than the
+        # mirrors asks for versions that have already been superseded and
+        # removed, and every mirror answers 404 — which is how the very first
+        # step of a fresh install failed. Refreshing without upgrading (-Sy)
+        # would leave a partial upgrade behind instead, so it is the full one.
+        run_cmd(
+            ["sudo", "pacman", "-Syu", "--needed", "--noconfirm", *packages_to_install]
+        )
         print("Core tools installation completed.")
     else:
         print("All core tools are already installed.")

--- a/.config/hypr/maintenance/components/essentials.py
+++ b/.config/hypr/maintenance/components/essentials.py
@@ -29,7 +29,12 @@ class Colors:
 
 def install_core_tools() -> None:
     packages_to_install: list[str] = []
-    packages_names = ["git", "fzf", "figlet", "lolcat"]
+    # No lolcat here. The repo one is ruby's, which drags in ruby, rubygems and
+    # rdoc for a banner — and the package list installs `c-lolcat` later, which
+    # *conflicts* with it, so the install stopped to ask permission to remove
+    # what it had just put on. The banners already tolerate it being absent
+    # (every call is check=False), and c-lolcat provides the same command.
+    packages_names = ["git", "fzf", "figlet"]
 
     print("Checking core tools installation...")
 

--- a/.config/hypr/maintenance/components/kirie.py
+++ b/.config/hypr/maintenance/components/kirie.py
@@ -31,8 +31,8 @@ INSTALL_PATH = Path.home() / ".local/bin/kirie"
 STAMP_PATH = Path.home() / ".local/share/kirie/installed-version"
 
 
-def _latest_release() -> tuple[str, str] | None:
-    """The latest release tag and the download URL of the asset."""
+def _latest_release() -> tuple[str, dict[str, str]] | None:
+    """The latest release tag and its assets, keyed by file name."""
     try:
         request = urllib.request.Request(
             RELEASE_API, headers={"Accept": "application/vnd.github+json"}
@@ -43,12 +43,15 @@ def _latest_release() -> tuple[str, str] | None:
         print(f"Could not reach the kirie release feed: {error}")
         return None
 
-    for asset in release.get("assets", []):
-        if asset.get("name") == ASSET:
-            return release.get("tag_name", ""), asset["browser_download_url"]
-
-    print(f"Release {release.get('tag_name')} has no {ASSET} asset")
-    return None
+    assets = {
+        asset.get("name", ""): asset.get("browser_download_url", "")
+        for asset in release.get("assets", [])
+    }
+    tag = release.get("tag_name", "")
+    if ASSET not in assets:
+        print(f"Release {tag} has no {ASSET} asset")
+        return None
+    return tag, assets
 
 
 def install_kirie() -> None:
@@ -64,7 +67,7 @@ def install_kirie() -> None:
     latest = _latest_release()
     if latest is None:
         return
-    tag, url = latest
+    tag, assets = latest
 
     installed = STAMP_PATH.read_text().strip() if STAMP_PATH.is_file() else ""
     if installed == tag and INSTALL_PATH.is_file():
@@ -73,21 +76,29 @@ def install_kirie() -> None:
 
     ensure_dir(INSTALL_PATH.parent)
     ensure_dir(STAMP_PATH.parent)
-    download_path = INSTALL_PATH.with_suffix(".download")
 
-    print(f"Downloading kirie {tag}...")
+    if not _download(assets[ASSET], INSTALL_PATH, f"kirie {tag}"):
+        return
+
+    STAMP_PATH.write_text(f"{tag}\n")
+    print(f"Installed kirie {tag} to {INSTALL_PATH}")
+
+
+def _download(url: str, target: Path, what: str) -> bool:
+    """Fetch one binary into place, atomically. True when it landed."""
+    download_path = target.with_suffix(".download")
+    print(f"Downloading {what}...")
     try:
         urllib.request.urlretrieve(url, download_path)
     except Exception as error:
-        print(f"Failed to download kirie: {error}")
+        print(f"Failed to download {what}: {error}")
         download_path.unlink(missing_ok=True)
-        return
+        return False
 
     # Replace in one step: a half-written binary is worse than the old one.
     download_path.chmod(0o755)
-    os.replace(download_path, INSTALL_PATH)
-    STAMP_PATH.write_text(f"{tag}\n")
-    print(f"Installed kirie {tag} to {INSTALL_PATH}")
+    os.replace(download_path, target)
+    return True
 
 
 def main() -> None:

--- a/.config/hypr/maintenance/components/kirie.py
+++ b/.config/hypr/maintenance/components/kirie.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import urllib.request
@@ -83,7 +84,43 @@ def install_kirie() -> None:
 
     STAMP_PATH.write_text(f"{tag}\n")
     print(f"Installed kirie {tag} to {INSTALL_PATH}")
+    _ensure_on_path()
     _report_readiness()
+
+
+def _ensure_on_path() -> None:
+    """Make ~/.local/bin reachable, in the session and in shells.
+
+    kirie installs here because it is not a package, and on a machine where
+    nothing else has ever installed to ~/.local/bin that directory is on
+    nobody's PATH — so `kirie` answers "command not found" on a machine that
+    has it.
+    """
+    bin_dir = INSTALL_PATH.parent
+    if shutil.which("kirie"):
+        return
+
+    # The systemd user session: what SDDM starts, and therefore what the panel
+    # and every launcher inherit.
+    env_file = Path.home() / ".config/environment.d/10-local-bin.conf"
+    ensure_dir(env_file.parent)
+    if not env_file.is_file() or "local/bin" not in env_file.read_text():
+        env_file.write_text(f'PATH="{bin_dir}:$PATH"\n')
+
+    # Interactive shells. ArchEclipse ships its own .zshrc with this already,
+    # so only files it does not own are appended to — and only when the
+    # directory is not mentioned at all, so re-running changes nothing.
+    for name in (".bashrc", ".profile"):
+        rc = Path.home() / name
+        if not rc.is_file():
+            continue
+        if "local/bin" in rc.read_text():
+            continue
+        with rc.open("a") as handle:
+            handle.write(f'\nexport PATH="{bin_dir}:$PATH"\n')
+
+    print(f"  ! {bin_dir} was not on PATH; added it.")
+    print("    Open a new shell or log out and back in for `kirie` to resolve.")
 
 
 def _report_readiness() -> None:

--- a/.config/hypr/maintenance/components/kirie.py
+++ b/.config/hypr/maintenance/components/kirie.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import urllib.request
 from pathlib import Path
@@ -82,6 +83,37 @@ def install_kirie() -> None:
 
     STAMP_PATH.write_text(f"{tag}\n")
     print(f"Installed kirie {tag} to {INSTALL_PATH}")
+    _report_readiness()
+
+
+def _report_readiness() -> None:
+    """Say what kirie still needs, while the user is here to act on it.
+
+    The binary installing successfully is not the same as it being able to
+    render: it needs a Vulkan driver, and Wallpaper Engine's own assets for
+    scene wallpapers. Both are silent failures later — an empty wallpaper
+    picker, or a wallpaper that never appears.
+    """
+    try:
+        gpus = subprocess.run(
+            [str(INSTALL_PATH), "gpus"], capture_output=True, text=True, timeout=60
+        )
+        if "no Vulkan adapter" in (gpus.stdout + gpus.stderr):
+            print("  ! No Vulkan driver found; kirie cannot render here.")
+            print("    Install the one for your GPU: vulkan-radeon, vulkan-intel,")
+            print("    nvidia-utils — or vulkan-swrast to render on the CPU.")
+    except Exception:
+        pass
+
+    try:
+        assets = subprocess.run(
+            [str(INSTALL_PATH), "assets"], capture_output=True, text=True, timeout=60
+        )
+        if assets.returncode != 0:
+            print("  ! Wallpaper Engine is not installed; scene wallpapers need its")
+            print("    shared assets. Install it via Steam, or set KIRIE_WE_ASSETS.")
+    except Exception:
+        pass
 
 
 def _download(url: str, target: Path, what: str) -> bool:

--- a/.config/hypr/maintenance/components/kirie.py
+++ b/.config/hypr/maintenance/components/kirie.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 import urllib.request
@@ -96,9 +95,12 @@ def _ensure_on_path() -> None:
     nobody's PATH — so `kirie` answers "command not found" on a machine that
     has it.
     """
+    # Deliberately not `shutil.which`: that answers for the *installer's*
+    # environment, and this runs from whatever shell the user started it in.
+    # A login zsh can be missing the directory while the bash running this has
+    # it. What matters is whether the persistent config mentions it.
     bin_dir = INSTALL_PATH.parent
-    if shutil.which("kirie"):
-        return
+    changed = False
 
     # The systemd user session: what SDDM starts, and therefore what the panel
     # and every launcher inherit.
@@ -106,6 +108,7 @@ def _ensure_on_path() -> None:
     ensure_dir(env_file.parent)
     if not env_file.is_file() or "local/bin" not in env_file.read_text():
         env_file.write_text(f'PATH="{bin_dir}:$PATH"\n')
+        changed = True
 
     # Interactive shells. ArchEclipse ships its own .zshrc with this already,
     # so only files it does not own are appended to — and only when the
@@ -118,9 +121,11 @@ def _ensure_on_path() -> None:
             continue
         with rc.open("a") as handle:
             handle.write(f'\nexport PATH="{bin_dir}:$PATH"\n')
+        changed = True
 
-    print(f"  ! {bin_dir} was not on PATH; added it.")
-    print("    Open a new shell or log out and back in for `kirie` to resolve.")
+    if changed:
+        print(f"  Added {bin_dir} to PATH.")
+        print("  Open a new shell or log out and back in for `kirie` to resolve.")
 
 
 def _report_readiness() -> None:

--- a/.config/hypr/maintenance/components/kirie.py
+++ b/.config/hypr/maintenance/components/kirie.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Wallpaper Engine renderer (kirie) setup.
+
+kirie renders Wallpaper Engine wallpapers on Wayland. It is a single static
+binary published on GitHub rather than a package, so it is fetched here into
+~/.local/bin instead of going through the AUR helper with everything else.
+
+The wallpaper switcher and the settings panel only show their Wallpaper Engine
+parts when this binary is present, so skipping this step costs nothing beyond
+those features.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from components.utils import command_exists, ensure_dir, run_shell
+else:
+    from .utils import command_exists, ensure_dir, run_shell
+
+RELEASE_API = "https://api.github.com/repos/UnhingedSoftware/kirie/releases/latest"
+# The webview build renders web wallpapers too, which a plain build cannot.
+ASSET = "kirie-web-webview-linux-x86_64"
+INSTALL_PATH = Path.home() / ".local/bin/kirie"
+STAMP_PATH = Path.home() / ".local/share/kirie/installed-version"
+
+
+def _latest_release() -> tuple[str, str] | None:
+    """The latest release tag and the download URL of the asset."""
+    try:
+        request = urllib.request.Request(
+            RELEASE_API, headers={"Accept": "application/vnd.github+json"}
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            release = json.load(response)
+    except Exception as error:  # offline, rate limited, API change
+        print(f"Could not reach the kirie release feed: {error}")
+        return None
+
+    for asset in release.get("assets", []):
+        if asset.get("name") == ASSET:
+            return release.get("tag_name", ""), asset["browser_download_url"]
+
+    print(f"Release {release.get('tag_name')} has no {ASSET} asset")
+    return None
+
+
+def install_kirie() -> None:
+    run_shell("echo ' ArchEclipse ' | lolcat", check=False)
+    run_shell("figlet 'WALLPAPER ENGINE' -f slant | lolcat", check=False)
+
+    # A kirie that ArchEclipse did not install is someone's own build or
+    # package; replacing it with a release would throw their work away.
+    if not STAMP_PATH.is_file() and (INSTALL_PATH.is_file() or command_exists("kirie")):
+        print("kirie is already installed by other means; leaving it alone")
+        return
+
+    latest = _latest_release()
+    if latest is None:
+        return
+    tag, url = latest
+
+    installed = STAMP_PATH.read_text().strip() if STAMP_PATH.is_file() else ""
+    if installed == tag and INSTALL_PATH.is_file():
+        print(f"kirie {tag} already installed")
+        return
+
+    ensure_dir(INSTALL_PATH.parent)
+    ensure_dir(STAMP_PATH.parent)
+    download_path = INSTALL_PATH.with_suffix(".download")
+
+    print(f"Downloading kirie {tag}...")
+    try:
+        urllib.request.urlretrieve(url, download_path)
+    except Exception as error:
+        print(f"Failed to download kirie: {error}")
+        download_path.unlink(missing_ok=True)
+        return
+
+    # Replace in one step: a half-written binary is worse than the old one.
+    download_path.chmod(0o755)
+    os.replace(download_path, INSTALL_PATH)
+    STAMP_PATH.write_text(f"{tag}\n")
+    print(f"Installed kirie {tag} to {INSTALL_PATH}")
+
+
+def main() -> None:
+    install_kirie()
+
+
+if __name__ == "__main__":
+    main()

--- a/.config/hypr/maintenance/components/packages.py
+++ b/.config/hypr/maintenance/components/packages.py
@@ -112,10 +112,37 @@ def install_packages(aur_helper: str = "yay") -> None:
     run_shell("figlet 'PACKAGES' -f slant | lolcat", check=False)
 
     pkg_input = "\n".join(PACKAGES)
-    run_cmd(
+    batch = run_cmd(
         [aur_helper, "-Syu", "--needed", "-"],
         input_text=pkg_input,
+        check=False,
     )
+    if batch.returncode == 0:
+        return
+
+    # One package can fail for reasons that have nothing to do with the rest —
+    # an AUR PKGBUILD that installs into /usr/local and collides with the
+    # filesystem package, a build that breaks against a new toolchain, a
+    # dependency pulled from under it. Installed as one transaction, that
+    # single failure means the machine gets *no* packages at all and the
+    # install stops on its first real step.
+    print("\nBatch install failed; retrying one package at a time...")
+    failed: list[str] = []
+    for package in PACKAGES:
+        result = run_cmd(
+            [aur_helper, "-S", "--needed", "--noconfirm", package],
+            check=False,
+        )
+        if result.returncode != 0:
+            failed.append(package)
+
+    if failed:
+        # Not fatal: the desktop works without any one of these, and the user
+        # can see exactly what to chase rather than a wall of pacman output.
+        print("\nThese packages could not be installed:")
+        for package in failed:
+            print(f"  - {package}")
+        print("Everything else is installed; install these by hand if you want them.")
 
 
 def main() -> None:

--- a/.config/hypr/maintenance/components/packages.py
+++ b/.config/hypr/maintenance/components/packages.py
@@ -120,12 +120,7 @@ def install_packages(aur_helper: str = "yay") -> None:
     if batch.returncode == 0:
         return
 
-    # One package can fail for reasons that have nothing to do with the rest —
-    # an AUR PKGBUILD that installs into /usr/local and collides with the
-    # filesystem package, a build that breaks against a new toolchain, a
-    # dependency pulled from under it. Installed as one transaction, that
-    # single failure means the machine gets *no* packages at all and the
-    # install stops on its first real step.
+    # As one transaction, a single bad AUR package means none of them install.
     print("\nBatch install failed; retrying one package at a time...")
     failed: list[str] = []
     for package in PACKAGES:
@@ -137,8 +132,7 @@ def install_packages(aur_helper: str = "yay") -> None:
             failed.append(package)
 
     if failed:
-        # Not fatal: the desktop works without any one of these, and the user
-        # can see exactly what to chase rather than a wall of pacman output.
+        # Not fatal: the desktop works without any one of these.
         print("\nThese packages could not be installed:")
         for package in failed:
             print(f"  - {package}")

--- a/.config/hypr/maintenance/components/plugins.py
+++ b/.config/hypr/maintenance/components/plugins.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -16,6 +17,13 @@ else:
 def install_plugins() -> None:
     run_shell("echo ' ArchEclipse ' | lolcat", check=False)
     run_shell("figlet 'PLUGINS' -f slant | lolcat", check=False)
+
+    # hyprpm needs a running Hyprland to know which version to build against.
+    if not os.environ.get("HYPRLAND_INSTANCE_SIGNATURE"):
+        print("Hyprland is not running; skipping plugins.")
+        print("Run this step again from inside a Hyprland session:")
+        print("  python3 ~/ArchEclipse/.config/hypr/maintenance/components/plugins.py")
+        return
 
     run_cmd(["hyprpm", "update"])
 

--- a/.config/hypr/maintenance/install.py
+++ b/.config/hypr/maintenance/install.py
@@ -63,6 +63,7 @@ def load_components(maintenance_dir: Path) -> dict[str, Any]:
         "defaults": importlib.import_module("components.defaults"),
         "sddm": importlib.import_module("components.sddm"),
         "wallpapers": importlib.import_module("components.wallpapers"),
+        "kirie": importlib.import_module("components.kirie"),
         "plugins": importlib.import_module("components.plugins"),
         "tweaks": importlib.import_module("components.tweaks"),
     }
@@ -195,6 +196,11 @@ def main() -> None:
                 "wallpapers", "Setting up wallpapers", default_choice="y"
             ),
             presentation.PlannedStep(
+                "wallpaper_engine",
+                "Installing the Wallpaper Engine renderer",
+                default_choice="y",
+            ),
+            presentation.PlannedStep(
                 "plugins", "Installing plugins", default_choice="y"
             ),
             presentation.PlannedStep(
@@ -296,6 +302,12 @@ def main() -> None:
         "Setting up wallpapers",
         modules["wallpapers"].main,
         run=plan["wallpapers"],
+    )
+    presentation.execute_planned_step(
+        "*",
+        "Installing the Wallpaper Engine renderer",
+        modules["kirie"].install_kirie,
+        run=plan["wallpaper_engine"],
     )
 
     presentation.print_section_header("PLUGINS & TWEAKS")

--- a/.config/hypr/maintenance/install.py
+++ b/.config/hypr/maintenance/install.py
@@ -82,9 +82,6 @@ def parse_branch(argv: list[str]) -> tuple[str, str]:
     - default: `master`
 
     Repository precedence: `--repo/-r`, env `ARCHECLIPSE_REPO`, then upstream.
-    A branch only exists somewhere, so pinning the branch without being able to
-    pin the repo made a fork impossible to install from — including for the
-    person testing their own before opening a pull request.
     """
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument(
@@ -123,9 +120,8 @@ def parse_branch(argv: list[str]) -> tuple[str, str]:
 def main() -> None:
     conf_dir = Path.home() / "ArchEclipse"
 
-    # Arguments first, and nothing destructive before them: the clone used to
-    # be deleted before argparse ran, so `install.py --help` — which only ever
-    # prints usage and exits — wiped ~/ArchEclipse on the way there.
+    # Before anything destructive: `--help` used to wipe ~/ArchEclipse on its
+    # way to printing usage.
     branch, repo = parse_branch(sys.argv)
 
     try:

--- a/.config/hypr/maintenance/install.py
+++ b/.config/hypr/maintenance/install.py
@@ -70,13 +70,21 @@ def load_components(maintenance_dir: Path) -> dict[str, Any]:
     return components
 
 
-def parse_branch(argv: list[str]) -> str:
+DEFAULT_REPO = "https://github.com/AymanLyesri/ArchEclipse.git"
+
+
+def parse_branch(argv: list[str]) -> tuple[str, str]:
     """
     Branch precedence:
     - `--branch/-b <name>`
     - legacy positional `<branch>` (argv[1])
     - env `ARCHECLIPSE_BRANCH`
     - default: `master`
+
+    Repository precedence: `--repo/-r`, env `ARCHECLIPSE_REPO`, then upstream.
+    A branch only exists somewhere, so pinning the branch without being able to
+    pin the repo made a fork impossible to install from — including for the
+    person testing their own before opening a pull request.
     """
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument(
@@ -84,6 +92,12 @@ def parse_branch(argv: list[str]) -> str:
         "--branch",
         default=None,
         help="ArchEclipse git branch to clone (default: master)",
+    )
+    parser.add_argument(
+        "-r",
+        "--repo",
+        default=None,
+        help=f"ArchEclipse git repository to clone (default: {DEFAULT_REPO})",
     )
     parser.add_argument(
         "legacy_branch",
@@ -94,17 +108,25 @@ def parse_branch(argv: list[str]) -> str:
 
     args = parser.parse_args(argv[1:])
 
+    branch = "master"
     if args.branch:
-        return str(args.branch)
-    if args.legacy_branch:
-        return str(args.legacy_branch)
-    if os.environ.get("ARCHECLIPSE_BRANCH"):
-        return str(os.environ["ARCHECLIPSE_BRANCH"])
-    return "master"
+        branch = str(args.branch)
+    elif args.legacy_branch:
+        branch = str(args.legacy_branch)
+    elif os.environ.get("ARCHECLIPSE_BRANCH"):
+        branch = str(os.environ["ARCHECLIPSE_BRANCH"])
+
+    repo = str(args.repo or os.environ.get("ARCHECLIPSE_REPO") or DEFAULT_REPO)
+    return branch, repo
 
 
 def main() -> None:
     conf_dir = Path.home() / "ArchEclipse"
+
+    # Arguments first, and nothing destructive before them: the clone used to
+    # be deleted before argparse ran, so `install.py --help` — which only ever
+    # prints usage and exits — wiped ~/ArchEclipse on the way there.
+    branch, repo = parse_branch(sys.argv)
 
     try:
         run_cmd(["curl", "-s", "-o", "/dev/null", COUNTER_URL], check=False)
@@ -119,9 +141,7 @@ def main() -> None:
         print(f"Repository already exists at {conf_dir}; overwriting")
         shutil.rmtree(conf_dir)
 
-    branch = parse_branch(sys.argv)
-
-    print("Cloning ArchEclipse repository (latest commit only)...")
+    print(f"Cloning {repo} ({branch}, latest commit only)...")
     run_cmd(
         [
             "git",
@@ -131,7 +151,7 @@ def main() -> None:
             "--single-branch",
             "--branch",
             branch,
-            "https://github.com/AymanLyesri/ArchEclipse.git",
+            repo,
             str(conf_dir),
         ]
     )

--- a/.config/hypr/maintenance/update.py
+++ b/.config/hypr/maintenance/update.py
@@ -44,6 +44,7 @@ def load_components(maintenance_dir: Path) -> dict[str, Any]:
         "presentation": importlib.import_module("components.presentation"),
         "packages": importlib.import_module("components.packages"),
         "plugins": importlib.import_module("components.plugins"),
+        "kirie": importlib.import_module("components.kirie"),
     }
 
 
@@ -209,6 +210,11 @@ def main() -> None:
                 "packages", package_description, default_choice="y"
             ),
             presentation.PlannedStep(
+                "wallpaper_engine",
+                "Updating the Wallpaper Engine renderer",
+                default_choice="y",
+            ),
+            presentation.PlannedStep(
                 "plugins", "Updating plugins", default_choice="y"
             ),
         ],
@@ -270,6 +276,14 @@ def main() -> None:
             lambda: modules["packages"].install_packages(aur_helper),
             run=False,
         )
+
+    presentation.print_section_header("WALLPAPER ENGINE")
+    presentation.execute_planned_step(
+        "*",
+        "Updating the Wallpaper Engine renderer",
+        modules["kirie"].install_kirie,
+        run=plan["wallpaper_engine"],
+    )
 
     presentation.print_section_header("PLUGINS")
     presentation.execute_planned_step(

--- a/.config/hypr/scripts-c/wallpaper-loop.c
+++ b/.config/hypr/scripts-c/wallpaper-loop.c
@@ -243,40 +243,63 @@ void expand_path(const char* input, char* output, size_t output_size) {
 }
 
 /*
- * Get wallpaper path for specific workspace
- * Reads from monitor-specific config file
- * Format: w-{workspace_id}={wallpaper_path}
+ * Read a monitor's wallpaper key
+ * Format: {key}={value}, one per line
  */
-bool get_wallpaper_for_workspace(const char* monitor, int workspace_id, char* wallpaper, size_t size) {
+static bool read_config_entry(const char* monitor, const char* key, char* value, size_t size) {
     char config_path[MAX_PATH_LEN];
     snprintf(config_path, sizeof(config_path), "%s/wallpaper-daemon/config/%s/defaults.conf", hypr_dir, monitor);
-    
+
     FILE* fp = fopen(config_path, "r");
     if (!fp) {
-        char error_msg[512];
-        snprintf(error_msg, sizeof(error_msg), "Cannot open config at %s: %s", config_path, strerror(errno));
-        notify_error("get_wallpaper_for_workspace", error_msg);
         return false;
     }
-    
+
     char line[MAX_LINE_LEN];
-    char ws_key[32];
-    snprintf(ws_key, sizeof(ws_key), "w-%d=", workspace_id);
-    
     bool found = false;
     while (fgets(line, sizeof(line), fp)) {
         line[strcspn(line, "\n")] = 0;
-        
-        if (strncmp(line, ws_key, strlen(ws_key)) == 0) {
-            strncpy(wallpaper, line + strlen(ws_key), size - 1);
-            wallpaper[size - 1] = '\0';
+        if (strncmp(line, key, strlen(key)) == 0) {
+            strncpy(value, line + strlen(key), size - 1);
+            value[size - 1] = '\0';
             found = true;
             break;
         }
     }
-    
+
     fclose(fp);
     return found;
+}
+
+/*
+ * True when this monitor shows one wallpaper on every workspace
+ * Format: mode=global
+ */
+bool is_global_mode(const char* monitor) {
+    char mode[32] = "";
+    return read_config_entry(monitor, "mode=", mode, sizeof(mode)) &&
+           strcmp(mode, "global") == 0;
+}
+
+/*
+ * Get wallpaper path for specific workspace
+ * Reads from monitor-specific config file
+ * Format: w-{workspace_id}={wallpaper_path}, or global={wallpaper_path} in
+ * global mode, where the workspace does not decide the wallpaper
+ */
+bool get_wallpaper_for_workspace(const char* monitor, int workspace_id, char* wallpaper, size_t size) {
+    char key[32];
+    if (is_global_mode(monitor)) {
+        snprintf(key, sizeof(key), "global=");
+    } else {
+        snprintf(key, sizeof(key), "w-%d=", workspace_id);
+    }
+
+    if (!read_config_entry(monitor, key, wallpaper, size)) {
+        return false;
+    }
+
+    return true;
 }
 
 /*

--- a/.config/hypr/scripts-c/wallpaper-loop.c
+++ b/.config/hypr/scripts-c/wallpaper-loop.c
@@ -430,21 +430,6 @@ bool is_hyprpaper_running() {
     return system("pgrep -x hyprpaper >/dev/null 2>&1") == 0;
 }
 
-/* Check if wallpaper should be rendered via mpvpaper */
-bool is_media_wallpaper(const char* wallpaper) {
-    if (!wallpaper) {
-        return false;
-    }
-
-    const char* dot = strrchr(wallpaper, '.');
-    if (!dot || *(dot + 1) == '\0') {
-        return false;
-    }
-
-    const char* ext = dot + 1;
-    return strcasecmp(ext, "gif") == 0 || strcasecmp(ext, "mp4") == 0 || strcasecmp(ext, "webm") == 0;
-}
-
 /* Kill any running wallpaper script instances */
 void kill_wallpaper_script() {
     char cmd[MAX_PATH_LEN];
@@ -521,11 +506,7 @@ void change_wallpaper() {
         
         /* Execute wallpaper change script */
         char cmd[MAX_PATH_LEN * 2];
-        if (is_media_wallpaper(expanded_wallpaper)) {
-            snprintf(cmd, sizeof(cmd), "%s/wallpaper-daemon/mpvpaper.sh '%s' '%s' &", hypr_dir, monitor, expanded_wallpaper);
-        } else {
-            snprintf(cmd, sizeof(cmd), "%s/wallpaper-daemon/hyprpaper.sh '%s' '%s' &", hypr_dir, monitor, expanded_wallpaper);
-        }
+        snprintf(cmd, sizeof(cmd), "%s/wallpaper-daemon/apply.sh '%s' '%s' &", hypr_dir, monitor, expanded_wallpaper);
         system(cmd);
         
         /* Update monitor state */

--- a/.config/hypr/scripts/bar.sh
+++ b/.config/hypr/scripts/bar.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
-AGS_TMP="/tmp/ags-${USER}"
+set -u
+
+AGS_TMP="/tmp/ags-${USER:-$(id -un)}"
 mkdir -p "$AGS_TMP"
 
-ags quit
+if ! ags bundle "$HOME/.config/ags/app.tsx" "$AGS_TMP/ags-bin.new"; then
+    echo "bar.sh: bundle failed; leaving the running shell alone" >&2
+    rm -f "$AGS_TMP/ags-bin.new"
+    exit 1
+fi
+
+mv -f "$AGS_TMP/ags-bin.new" "$AGS_TMP/ags-bin"
+
+ags quit >/dev/null 2>&1
 
 killall gjs >/dev/null 2>&1
 
-ags bundle $HOME/.config/ags/app.tsx $AGS_TMP/ags-bin
-
-# output log to $AGS_TMP/ags-bin.log
-nohup $AGS_TMP/ags-bin > "$AGS_TMP/ags-bin.log" 2>&1 &
+nohup "$AGS_TMP/ags-bin" > "$AGS_TMP/ags-bin.log" 2>&1 &
 
 exit 0

--- a/.config/hypr/scripts/session-guard.sh
+++ b/.config/hypr/scripts/session-guard.sh
@@ -1,30 +1,16 @@
 #!/bin/bash
 
-# Bring the shell back after a compositor crash.
-#
-# Hyprland relaunches itself with `--safe-mode` when it dies, and safe mode
-# skips every `exec-once` — so the config and the keybinds come back but AGS,
-# hyprpaper, the wallpaper loop and the tray applets simply are not there. The
-# session looks broken until each one is started by hand.
-#
-# The crashes themselves are an amdgpu ring hang (the iGPU under a 1440p@360Hz
-# compositor); this does not fix that, it just stops one from costing the whole
-# desktop. Runs as a user service, checks every 20s, starts only what is
-# missing, and does nothing at all while the session is healthy.
-
 set -u
 
 interval=20
+backoffInterval=300
+maxFailures=3
 hyprDir="$HOME/.config/hypr"
+tmpDir="/tmp"
+failures=0
 
-# Match on the process NAME, never on the command line: a `pgrep -f` for a
-# pattern that appears in this script's own argv matches this script.
 running() { pgrep -x "$1" >/dev/null 2>&1; }
 
-# AGS's process name is `gjs`, and the bundle re-execs itself as
-# `gjs -m /run/user/<uid>/ags.js` — NOT as the ags-bin path it was started
-# from, which is what an earlier version of this check looked for. It decided
-# a perfectly healthy shell was missing and restarted it.
 ags_running() {
     local pid
     for pid in $(pgrep -x gjs 2>/dev/null); do
@@ -35,27 +21,79 @@ ags_running() {
     return 1
 }
 
-compositor_up() {
-    [ -n "$(ls -A "$XDG_RUNTIME_DIR/hypr" 2>/dev/null)" ] && running Hyprland
+resolve_session_env() {
+    local pid sock name dir sig
+
+    pid=$(pgrep -x Hyprland | head -1)
+    [ -n "$pid" ] || return 1
+
+    name=""
+    for sock in "$XDG_RUNTIME_DIR"/wayland-[0-9]*; do
+        [ -S "$sock" ] || continue
+        if ss -lxHp 2>/dev/null | grep -F " $sock " | grep -q "pid=$pid,"; then
+            name=$(basename "$sock")
+            break
+        fi
+    done
+    if [ -z "$name" ]; then
+        for sock in "$XDG_RUNTIME_DIR"/wayland-[0-9]*; do
+            [ -S "$sock" ] && name=$(basename "$sock")
+        done
+    fi
+    [ -n "$name" ] || return 1
+
+    sig=""
+    for dir in "$XDG_RUNTIME_DIR"/hypr/*/; do
+        [ -S "${dir}.socket.sock" ] || continue
+        if HYPRLAND_INSTANCE_SIGNATURE=$(basename "$dir") hyprctl version >/dev/null 2>&1; then
+            sig=$(basename "$dir")
+            break
+        fi
+    done
+    [ -n "$sig" ] || return 1
+
+    export WAYLAND_DISPLAY="$name"
+    export HYPRLAND_INSTANCE_SIGNATURE="$sig"
+    export XDG_CURRENT_DESKTOP=Hyprland
+    return 0
 }
 
 start_once() {
-    # `setsid` so nothing here dies with this service if it is restarted.
     setsid nohup "$@" >/dev/null 2>&1 &
 }
 
+ensure_wallpaper_loop() {
+    if [ ! -x "$tmpDir/wallpaper-loop" ]; then
+        gcc "$hyprDir/scripts-c/wallpaper-loop.c" -o "$tmpDir/wallpaper-loop" >/dev/null 2>&1 || return 1
+    fi
+    running wallpaper-loop || start_once "$tmpDir/wallpaper-loop"
+}
+
 while true; do
-    if compositor_up; then
-        if ! ags_running; then
+    if resolve_session_env; then
+        if ags_running; then
+            failures=0
+        else
             echo "session-guard: AGS is gone; restarting the shell"
-            start_once bash "$hyprDir/scripts/compile-run-binaries.sh"
-            # Give the bundle time to build before deciding it failed again.
+            start_once bash "$hyprDir/scripts/bar.sh"
             sleep 30
+            if ags_running; then
+                failures=0
+            else
+                failures=$((failures + 1))
+                echo "session-guard: AGS did not come back (failure $failures)"
+            fi
         fi
 
+        ensure_wallpaper_loop
         running hyprpaper || start_once hyprpaper
         running nm-applet || start_once nm-applet
         running blueman-applet || start_once blueman-applet
     fi
-    sleep "$interval"
+
+    if [ "$failures" -ge "$maxFailures" ]; then
+        sleep "$backoffInterval"
+    else
+        sleep "$interval"
+    fi
 done

--- a/.config/hypr/scripts/session-guard.sh
+++ b/.config/hypr/scripts/session-guard.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Bring the shell back after a compositor crash.
+#
+# Hyprland relaunches itself with `--safe-mode` when it dies, and safe mode
+# skips every `exec-once` — so the config and the keybinds come back but AGS,
+# hyprpaper, the wallpaper loop and the tray applets simply are not there. The
+# session looks broken until each one is started by hand.
+#
+# The crashes themselves are an amdgpu ring hang (the iGPU under a 1440p@360Hz
+# compositor); this does not fix that, it just stops one from costing the whole
+# desktop. Runs as a user service, checks every 20s, starts only what is
+# missing, and does nothing at all while the session is healthy.
+
+set -u
+
+interval=20
+hyprDir="$HOME/.config/hypr"
+
+# Match on the process NAME, never on the command line: a `pgrep -f` for a
+# pattern that appears in this script's own argv matches this script.
+running() { pgrep -x "$1" >/dev/null 2>&1; }
+
+# AGS's process name is `gjs`, and the bundle re-execs itself as
+# `gjs -m /run/user/<uid>/ags.js` — NOT as the ags-bin path it was started
+# from, which is what an earlier version of this check looked for. It decided
+# a perfectly healthy shell was missing and restarted it.
+ags_running() {
+    local pid
+    for pid in $(pgrep -x gjs 2>/dev/null); do
+        if tr '\0' '\n' <"/proc/$pid/cmdline" 2>/dev/null | grep -qE 'ags\.js|ags-bin'; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+compositor_up() {
+    [ -n "$(ls -A "$XDG_RUNTIME_DIR/hypr" 2>/dev/null)" ] && running Hyprland
+}
+
+start_once() {
+    # `setsid` so nothing here dies with this service if it is restarted.
+    setsid nohup "$@" >/dev/null 2>&1 &
+}
+
+while true; do
+    if compositor_up; then
+        if ! ags_running; then
+            echo "session-guard: AGS is gone; restarting the shell"
+            start_once bash "$hyprDir/scripts/compile-run-binaries.sh"
+            # Give the bundle time to build before deciding it failed again.
+            sleep 30
+        fi
+
+        running hyprpaper || start_once hyprpaper
+        running nm-applet || start_once nm-applet
+        running blueman-applet || start_once blueman-applet
+    fi
+    sleep "$interval"
+done

--- a/.config/hypr/wallpaper-daemon/apply.sh
+++ b/.config/hypr/wallpaper-daemon/apply.sh
@@ -16,6 +16,14 @@ if [ -z "$monitor" ] || [ -z "$wallpaper" ]; then
     exit 1
 fi
 
+# A Wallpaper Engine item is a directory with a project.json beside its assets.
+if [ -f "$wallpaper/project.json" ]; then
+    exec "$hyprDir/wallpaper-daemon/kirie.sh" "$monitor" "$wallpaper"
+fi
+
+# Anything else is a plain file, so the engine must let go of this monitor.
+"$hyprDir/wallpaper-daemon/kirie.sh" --stop "$monitor" >/dev/null 2>&1
+
 ext="${wallpaper##*.}"
 ext="$(printf '%s' "$ext" | tr '[:upper:]' '[:lower:]')"
 

--- a/.config/hypr/wallpaper-daemon/apply.sh
+++ b/.config/hypr/wallpaper-daemon/apply.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Apply a wallpaper on one monitor with whichever backend can render it.
+#
+# The wallpaper daemon has more than one renderer, and every caller used to
+# repeat the same guesswork about which one a given file needs. They call this
+# instead, so a new renderer is one case here rather than an edit in each
+# caller.
+
+hyprDir="$HOME/.config/hypr"
+monitor="$1"
+wallpaper="$2"
+
+if [ -z "$monitor" ] || [ -z "$wallpaper" ]; then
+    echo "Usage: apply.sh <monitor> <wallpaper>" >&2
+    exit 1
+fi
+
+ext="${wallpaper##*.}"
+ext="$(printf '%s' "$ext" | tr '[:upper:]' '[:lower:]')"
+
+case "$ext" in
+    gif | mp4 | webm)
+        exec "$hyprDir/wallpaper-daemon/mpvpaper.sh" "$monitor" "$wallpaper"
+        ;;
+    *)
+        exec "$hyprDir/wallpaper-daemon/hyprpaper.sh" "$monitor" "$wallpaper"
+        ;;
+esac

--- a/.config/hypr/wallpaper-daemon/kirie.sh
+++ b/.config/hypr/wallpaper-daemon/kirie.sh
@@ -114,6 +114,7 @@ launch() {
         flag_value --fps fps 30
         flag_value --playback-speed playbackSpeed 1
         flag_value --render-scale renderScale 1
+        flag_value --battery-fps batteryFps 10
         # --silent is the muted form of --volume; passing both is contradictory.
         [ "$(setting mute false)" = "true" ] || flag_value --volume volume 15
         flag_value --audio-device audioDevice ""
@@ -164,11 +165,7 @@ launch() {
     # setsid detaches, so its own pid is not the engine's; ask for the real one.
     pgrep -nx kirie >"$pidFile"
 
-    # Settings and per-screen overrides the command line cannot carry.
-    local batteryFps
-    batteryFps="$(setting batteryFps "")"
-    [ -n "$batteryFps" ] && send "set batteryfps $batteryFps" 5 >/dev/null
-
+    # Per-screen overrides the command line cannot carry.
     first=1
     while read -r monitor item; do
         [ -n "$monitor" ] && [ -n "$item" ] || continue

--- a/.config/hypr/wallpaper-daemon/kirie.sh
+++ b/.config/hypr/wallpaper-daemon/kirie.sh
@@ -18,6 +18,14 @@ runtime="${XDG_RUNTIME_DIR:-/tmp}"
 socket="$runtime/lwe.sock"
 pidFile="$runtime/kirie.pid"
 logFile="$runtime/kirie.log"
+lockFile="$runtime/kirie.lock"
+
+# One engine serves every screen, so only one invocation may decide whether to
+# launch one. Applying a wallpaper to two monitors at once — which is exactly
+# what happens at login — otherwise has both calls find no engine running and
+# start their own, leaving a process per monitor, each owning one screen.
+exec 9>"$lockFile"
+flock 9
 
 # The engine is installed per user, and the session PATH does not always carry
 # ~/.local/bin when the compositor spawns the wallpaper daemon.
@@ -78,7 +86,18 @@ flag_bool() {
 
 # The screens the running engine owns, as `<monitor> <item>` lines.
 screens() {
-    send status 5 2>/dev/null | sed -n 's/^screen=\(.*\) bg=\(.*\)$/\1 \2/p'
+    local out
+    # A freshly launched engine answers `ping` before it has registered its
+    # screens, so an immediate `status` comes back empty — and a caller adding
+    # a second monitor would then relaunch with only its own, dropping the
+    # wallpaper that was already up. Give it a moment to name them.
+    for _ in $(seq 1 10); do
+        out="$(send status 5 2>/dev/null | sed -n 's/^screen=\(.*\) bg=\(.*\)$/\1 \2/p')"
+        [ -n "$out" ] && break
+        alive || break
+        sleep 0.3
+    done
+    printf '%s' "$out"
 }
 
 # The property overrides saved for an item, as `<key> <value>` lines.
@@ -104,7 +123,9 @@ stop_engine() {
     done
 }
 
-# Launch one engine for every `<monitor> <item>` line in $1.
+# Launch ONE engine owning every `<monitor> <item>` line in $1: each becomes a
+# `--screen-root`/`--bg` pair. kirie drives every screen from one process, and
+# a second instance would fight it for the same control socket.
 launch() {
     local lines="$1"
     local args=() globals=() first=1 monitor item
@@ -151,7 +172,10 @@ launch() {
         fi
     done <<<"$lines"
 
-    setsid "$kirieBin" "${args[@]}" >"$logFile" 2>&1 &
+    # 9>&- closes the lock fd in the engine: it inherits every open descriptor,
+    # and an engine holding the lock for its whole life blocks every later
+    # invocation of this script forever.
+    setsid "$kirieBin" "${args[@]}" >"$logFile" 2>&1 9>&- &
 
     local ready=1
     for _ in $(seq 1 50); do

--- a/.config/hypr/wallpaper-daemon/kirie.sh
+++ b/.config/hypr/wallpaper-daemon/kirie.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+
+# Render a Wallpaper Engine item with kirie.
+#
+#   kirie.sh <monitor> <item-dir>   render the item on that monitor
+#   kirie.sh --stop [monitor]       drop one monitor (or the whole engine)
+#   kirie.sh --restart              relaunch with the same screens
+#
+# One engine process serves every monitor, so switching workspaces is a `bg`
+# command over its control socket rather than a restart. The engine is only
+# relaunched when the set of screens it must own changes, or when a setting
+# that can only be given on the command line was edited.
+
+hyprDir="$HOME/.config/hypr"
+settingsFile="$HOME/.config/ags/cache/settings/settings.json"
+overrideDir="$HOME/.config/ags/cache/wallpaper-engine"
+runtime="${XDG_RUNTIME_DIR:-/tmp}"
+socket="$runtime/lwe.sock"
+pidFile="$runtime/kirie.pid"
+logFile="$runtime/kirie.log"
+
+# The engine is installed per user, and the session PATH does not always carry
+# ~/.local/bin when the compositor spawns the wallpaper daemon.
+kirieBin="$(command -v kirie 2>/dev/null)"
+[ -n "$kirieBin" ] || kirieBin="$HOME/.local/bin/kirie"
+
+# Send one line to the control socket and print the reply. python3 is already a
+# hard dependency of the maintenance scripts, so this needs no extra package.
+send() {
+    python3 -c '
+import socket, sys
+try:
+    s = socket.socket(socket.AF_UNIX)
+    s.settimeout(float(sys.argv[3]))
+    s.connect(sys.argv[1])
+    s.sendall(sys.argv[2].encode() + b"\n")
+    while True:
+        chunk = s.recv(4096)
+        if not chunk:
+            break
+        sys.stdout.write(chunk.decode(errors="replace"))
+except OSError:
+    sys.exit(1)
+' "$socket" "$1" "${2:-20}"
+}
+
+alive() { send ping 2 2>/dev/null | grep -q '^pong'; }
+
+# One engine setting, or the given fallback. `tostring` rather than jq's `//`
+# operator, which treats a stored `false` as absent.
+setting() {
+    local value
+    [ -f "$settingsFile" ] || {
+        printf '%s' "$2"
+        return
+    }
+    value="$(jq -r --arg k "$1" \
+        '.wallpaperEngine[$k].value | if . == null then "" else tostring end' \
+        "$settingsFile" 2>/dev/null)"
+    [ -n "$value" ] && printf '%s' "$value" || printf '%s' "$2"
+}
+
+# `--flag=value` when the setting has one, nothing when it is empty/default.
+#
+# The `=` form is deliberate: an engine that predates a flag skips the whole
+# token, while `--flag value` leaves the value behind as a positional argument,
+# where it is read as a background id and kills the launch.
+flag_value() {
+    local value
+    value="$(setting "$2" "$3")"
+    [ -n "$value" ] && [ "$value" != "default" ] && printf '%s=%s\n' "$1" "$value"
+}
+
+# `--flag` when the boolean setting is on.
+flag_bool() {
+    [ "$(setting "$2" false)" = "true" ] && printf '%s\n' "$1"
+}
+
+# The screens the running engine owns, as `<monitor> <item>` lines.
+screens() {
+    send status 5 2>/dev/null | sed -n 's/^screen=\(.*\) bg=\(.*\)$/\1 \2/p'
+}
+
+# The property overrides saved for an item, as `<key> <value>` lines.
+overrides() {
+    local file="$overrideDir/$(basename "$1").json"
+    [ -f "$file" ] || return 0
+    jq -r 'to_entries[] | "\(.key) \(.value|tostring)"' "$file" 2>/dev/null
+}
+
+stop_engine() {
+    local pid
+    pid="$(cat "$pidFile" 2>/dev/null)"
+    if [ -n "$pid" ] && [ -d "/proc/$pid" ]; then
+        kill "$pid" 2>/dev/null
+    else
+        pkill -x kirie 2>/dev/null
+    fi
+    rm -f "$pidFile"
+    # The engine unlinks its own socket on the way out; do not outrun it.
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        [ -S "$socket" ] || break
+        sleep 0.2
+    done
+}
+
+# Launch one engine for every `<monitor> <item>` line in $1.
+launch() {
+    local lines="$1"
+    local args=() globals=() first=1 monitor item
+    args+=("--control-socket=$socket")
+
+    mapfile -t globals < <(
+        flag_value --fps fps 30
+        flag_value --playback-speed playbackSpeed 1
+        flag_value --render-scale renderScale 1
+        # --silent is the muted form of --volume; passing both is contradictory.
+        [ "$(setting mute false)" = "true" ] || flag_value --volume volume 15
+        flag_value --audio-device audioDevice ""
+        flag_value --layer layer bottom
+        flag_value --gpu gpu auto
+        flag_value --assets-dir assetsDir ""
+        flag_bool --silent mute
+        flag_bool --noautomute noAutomute
+        flag_bool --no-audio-processing noAudioProcessing
+        flag_bool --disable-mouse disableMouse
+        flag_bool --disable-parallax disableParallax
+        flag_bool --disable-particles disableParticles
+        flag_bool --no-fullscreen-pause noFullscreenPause
+        flag_bool --fullscreen-pause-only-active fullscreenPauseOnlyActive
+    )
+    args+=("${globals[@]}")
+
+    local scaling clamp
+    scaling="$(setting scaling default)"
+    clamp="$(setting clamp clamp)"
+
+    while read -r monitor item; do
+        [ -n "$monitor" ] && [ -n "$item" ] || continue
+        args+=("--screen-root=$monitor" "--bg=$item")
+        args+=("--scaling=$scaling" "--clamp=$clamp")
+        # Per-screen property overrides cannot be expressed on the command
+        # line, so only the first screen's are inlined; the rest are staged
+        # into their own `bg` below.
+        if [ "$first" = 1 ]; then
+            first=0
+            while read -r key value; do
+                [ -n "$key" ] && args+=("--set-property=$key=$value")
+            done < <(overrides "$item")
+        fi
+    done <<<"$lines"
+
+    setsid "$kirieBin" "${args[@]}" >"$logFile" 2>&1 &
+
+    local ready=1
+    for _ in $(seq 1 50); do
+        alive && {
+            ready=0
+            break
+        }
+        sleep 0.2
+    done
+    [ "$ready" = 0 ] || return 1
+    # setsid detaches, so its own pid is not the engine's; ask for the real one.
+    pgrep -nx kirie >"$pidFile"
+
+    # Settings and per-screen overrides the command line cannot carry.
+    local batteryFps
+    batteryFps="$(setting batteryFps "")"
+    [ -n "$batteryFps" ] && send "set batteryfps $batteryFps" 5 >/dev/null
+
+    first=1
+    while read -r monitor item; do
+        [ -n "$monitor" ] && [ -n "$item" ] || continue
+        if [ "$first" = 1 ]; then
+            first=0
+            continue
+        fi
+        [ -n "$(overrides "$item")" ] && apply_over_socket "$monitor" "$item"
+    done <<<"$lines"
+    return 0
+}
+
+# Apply an item on a screen the engine already owns: stage the saved overrides
+# so they land in the same rebuild as the wallpaper itself.
+apply_over_socket() {
+    local monitor="$1" item="$2" key value
+    while read -r key value; do
+        [ -n "$key" ] && send "stage $key $value" 5 >/dev/null
+    done < <(overrides "$item")
+    send "bg $monitor $item" 60 >/dev/null
+}
+
+# Hand the item's preview to the theme scripts: everything downstream expects
+# an image, and a wallpaper directory is not one.
+theme_from_preview() {
+    local preview
+    preview="$(find "$1" -maxdepth 1 -iname 'preview.*' | head -n 1)"
+    [ -n "$preview" ] || return 0
+    printf '%s\n' "$preview" >"$hyprDir/wallpaper-daemon/config/current.conf"
+    "$hyprDir/theme/scripts/wal-theme.sh" "$preview" >/dev/null 2>&1
+}
+
+case "$1" in
+    --stop)
+        monitor="$2"
+        if [ -z "$monitor" ] || ! alive; then
+            stop_engine
+            exit 0
+        fi
+        remaining="$(screens | grep -v "^$monitor ")"
+        stop_engine
+        [ -n "$remaining" ] && launch "$remaining"
+        exit 0
+        ;;
+    --restart)
+        alive || exit 0
+        current="$(screens)"
+        stop_engine
+        [ -n "$current" ] && launch "$current"
+        exit $?
+        ;;
+esac
+
+monitor="$1"
+item="$2"
+
+if [ -z "$monitor" ] || [ -z "$item" ]; then
+    echo "Usage: kirie.sh <monitor> <item-dir> | --stop [monitor] | --restart" >&2
+    exit 1
+fi
+
+if [ ! -x "$kirieBin" ]; then
+    notify-send -u critical "Wallpaper Engine" "kirie is not installed"
+    exit 1
+fi
+
+if alive && screens | grep -q "^$monitor "; then
+    apply_over_socket "$monitor" "$item"
+else
+    others="$(screens | grep -v "^$monitor ")"
+    stop_engine
+    lines="$monitor $item"
+    [ -n "$others" ] && lines="$lines"$'\n'"$others"
+    launch "$lines" ||
+        notify-send -u critical "Wallpaper Engine" "kirie failed to start, see $logFile"
+fi
+
+theme_from_preview "$item"

--- a/.config/hypr/wallpaper-daemon/set-wallpaper.sh
+++ b/.config/hypr/wallpaper-daemon/set-wallpaper.sh
@@ -37,14 +37,7 @@ if [ "$old_wallpaper" = "$wallpaper" ]; then
 fi
 
 if [ "$workspace_id" = "$current_workspace" ]; then
-    wallpaper_ext="${wallpaper##*.}"
-    wallpaper_ext="$(printf '%s' "$wallpaper_ext" | tr '[:upper:]' '[:lower:]')"
-    
-    if [ "$wallpaper_ext" = "gif" ] || [ "$wallpaper_ext" = "mp4" ] || [ "$wallpaper_ext" = "webm" ]; then
-        "$hyprDir/wallpaper-daemon/mpvpaper.sh" "$monitor" "$wallpaper" &
-    else
-        "$hyprDir/wallpaper-daemon/hyprpaper.sh" "$monitor" "$wallpaper" &
-    fi
+    "$hyprDir/wallpaper-daemon/apply.sh" "$monitor" "$wallpaper" &
 fi
 
 sed -i "s|^w-${workspace_id}=.*|w-${workspace_id}=${wallpaper}|" "$current_config"

--- a/.config/hypr/wallpaper-daemon/set-wallpaper.sh
+++ b/.config/hypr/wallpaper-daemon/set-wallpaper.sh
@@ -1,12 +1,73 @@
 #!/bin/bash
 
+# Record a wallpaper for a monitor, and show it right away when it is the one
+# that should currently be on screen.
+#
+#   set-wallpaper.sh <workspace_id> <monitor> [wallpaper]   per-workspace slot
+#   set-wallpaper.sh global <monitor> [wallpaper]           the one-for-all slot
+#   set-wallpaper.sh --mode <workspace|global> [monitor]    switch which is used
+#
+# The mode lives in the monitor's own config next to the wallpapers it applies
+# to, so the workspace watcher can read it without knowing anything about the
+# shell's settings.
+
 hyprDir="$HOME/.config/hypr"
-workspace_id="$1"
+configDir="$hyprDir/wallpaper-daemon/config"
+
+monitor_config() { printf '%s/%s/defaults.conf' "$configDir" "$1"; }
+
+wallpaper_mode() {
+    local mode
+    mode="$(grep '^mode=' "$(monitor_config "$1")" 2>/dev/null | cut -d'=' -f2- | head -n 1)"
+    [ "$mode" = "global" ] && echo global || echo workspace
+}
+
+# Write `<key>=<value>` into a monitor config, adding the line when it is new.
+write_entry() {
+    local config="$1" key="$2" value="$3"
+    grep -q "^${key}=" "$config" || echo "${key}=" >>"$config"
+    sed -i "s|^${key}=.*|${key}=${value}|" "$config"
+}
+
+read_entry() {
+    grep "^${2}=" "$1" 2>/dev/null | cut -d'=' -f2- | head -n 1
+}
+
+# --mode: record the mode, then show whatever that mode says belongs on screen.
+if [ "$1" = "--mode" ]; then
+    mode="$2"
+    if [ "$mode" != "workspace" ] && [ "$mode" != "global" ]; then
+        echo "Usage: set-wallpaper.sh --mode <workspace|global> [monitor]" >&2
+        exit 1
+    fi
+
+    monitors="$3"
+    [ -n "$monitors" ] || monitors="$(hyprctl monitors -j | jq -r '.[].name')"
+
+    for name in $monitors; do
+        config="$(monitor_config "$name")"
+        [ -f "$config" ] || continue
+        write_entry "$config" mode "$mode"
+
+        if [ "$mode" = "global" ]; then
+            wallpaper="$(read_entry "$config" global)"
+        else
+            workspace="$(hyprctl monitors -j |
+                jq -r --arg m "$name" '.[] | select(.name == $m) | .activeWorkspace.id')"
+            wallpaper="$(read_entry "$config" "w-${workspace}")"
+        fi
+
+        [ -n "$wallpaper" ] && "$hyprDir/wallpaper-daemon/apply.sh" "$name" "$wallpaper" &
+    done
+    exit 0
+fi
+
+target="$1"
 monitor="$2"
 wallpaper="$3"
 
-if [ -z "$workspace_id" ] || [ -z "$monitor" ]; then
-    echo "Usage: set-wallpaper.sh <workspace_id> <monitor> [wallpaper]"
+if [ -z "$target" ] || [ -z "$monitor" ]; then
+    echo "Usage: set-wallpaper.sh <workspace_id|global> <monitor> [wallpaper]"
     exit 1
 fi
 
@@ -18,26 +79,32 @@ if [ -z "$wallpaper" ]; then
     fi
 fi
 
-current_config="$hyprDir/wallpaper-daemon/config/$monitor/defaults.conf"
+current_config="$(monitor_config "$monitor")"
 if [ ! -f "$current_config" ]; then
     echo "Config not found for monitor '$monitor': $current_config"
     exit 1
 fi
 
-current_workspace="$(hyprctl monitors -j | jq -r --arg monitor "$monitor" '.[] | select(.name == $monitor) | .activeWorkspace.id')"
-
-if ! grep -q "^w-${workspace_id}=" "$current_config"; then
-    echo "w-${workspace_id}=" >> "$current_config"
+if [ "$target" = "global" ]; then
+    key="global"
+    # The global wallpaper is on screen whenever the monitor is in global mode.
+    [ "$(wallpaper_mode "$monitor")" = "global" ] && on_screen=1 || on_screen=0
+else
+    key="w-${target}"
+    current_workspace="$(hyprctl monitors -j |
+        jq -r --arg monitor "$monitor" '.[] | select(.name == $monitor) | .activeWorkspace.id')"
+    [ "$target" = "$current_workspace" ] &&
+        [ "$(wallpaper_mode "$monitor")" = "workspace" ] && on_screen=1 || on_screen=0
 fi
 
-old_wallpaper="$(grep "^w-${workspace_id}=" "$current_config" | cut -d'=' -f2- | head -n 1)"
+old_wallpaper="$(read_entry "$current_config" "$key")"
 if [ "$old_wallpaper" = "$wallpaper" ]; then
     echo "Wallpaper is already set to $wallpaper"
     exit 0
 fi
 
-if [ "$workspace_id" = "$current_workspace" ]; then
+if [ "$on_screen" = 1 ]; then
     "$hyprDir/wallpaper-daemon/apply.sh" "$monitor" "$wallpaper" &
 fi
 
-sed -i "s|^w-${workspace_id}=.*|w-${workspace_id}=${wallpaper}|" "$current_config"
+write_entry "$current_config" "$key" "$wallpaper"

--- a/.config/systemd/user/archeclipse-session-guard.service
+++ b/.config/systemd/user/archeclipse-session-guard.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Bring the ArchEclipse shell back after a compositor crash
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=%h/.config/hypr/scripts/session-guard.sh
+Restart=always
+RestartSec=5
+# The guard's whole job is to be cheap and dull; it must never be the reason
+# something else is starved.
+Nice=10
+
+[Install]
+WantedBy=default.target

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@
 !.config/
 .config/*
 
+# Include the user services ArchEclipse ships (the session guard has to be one:
+# it exists to restart the shell after a compositor crash, and Hyprland's
+# post-crash safe mode is exactly when exec-once does not run).
+!.config/systemd/
+!.config/systemd/user/
+
 # Include hyprland config
 !.config/hypr/
 # Include kitty config

--- a/.zshrc
+++ b/.zshrc
@@ -1,3 +1,10 @@
+# Anything installed per-user lands in ~/.local/bin (kirie, pipx, cargo
+# install --root ~/.local). Without this it is installed and not callable.
+case ":$PATH:" in
+    *":$HOME/.local/bin:"*) ;;
+    *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac
+
 (cat ~/.cache/cwal/sequences &)
 
 eval "$(starship init zsh)"

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ graph TB
 
 A custom pipeline generates a full system color scheme from the active wallpaper at runtime using [Cwal](https://github.com/nitinbhat972/cwal) a custom C implementation of PyWal (10-50x faster, zero Python overhead) that generates a full color scheme at runtime. Colors propagate automatically to GTK4 widgets, terminal, and all UI components. No manual color editing required — ever.
 
-- Per-workspace wallpaper assignment with static, animated (video) and Wallpaper Engine support
+- Per-workspace or one-for-all wallpaper assignment with static, animated (video) and Wallpaper Engine support
 - Global light/dark mode toggle with instant application across the entire environment
 - Color changes hot-reload without restarting any component
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ graph TB
         HyprMain["hyprland.lua<br/>entry point"]
         HyprConfig["config/*.lua<br/>bind, animations, monitor,<br/>windowrule, gesture, input"]
         HyprScripts["scripts / scripts-c<br/>screenshot, screenrecord,<br/>hyprlock, wallpaper-loop"]
-        WallpaperDaemon["wallpaper-daemon<br/>hyprpaper / mpvpaper"]
+        WallpaperDaemon["wallpaper-daemon<br/>hyprpaper / mpvpaper / kirie"]
         Evremap["evremap<br/>key remapping service"]
     end
 
@@ -147,7 +147,7 @@ graph TB
 
 A custom pipeline generates a full system color scheme from the active wallpaper at runtime using [Cwal](https://github.com/nitinbhat972/cwal) a custom C implementation of PyWal (10-50x faster, zero Python overhead) that generates a full color scheme at runtime. Colors propagate automatically to GTK4 widgets, terminal, and all UI components. No manual color editing required — ever.
 
-- Per-workspace wallpaper assignment with both static and animated (video) support
+- Per-workspace wallpaper assignment with static, animated (video) and Wallpaper Engine support
 - Global light/dark mode toggle with instant application across the entire environment
 - Color changes hot-reload without restarting any component
 

--- a/docs/06_VISUAL_STYLING.md
+++ b/docs/06_VISUAL_STYLING.md
@@ -369,6 +369,26 @@ wallpaper = DP-1,$HOME/.config/wallpapers/background.png
 
 The blur effect uses your wallpaper as a base for the blur.
 
+### One Wallpaper Everywhere
+
+Wallpapers are per workspace by default. Set **Wallpaper Mode** to *Global* in
+`SUPER` + `L` to use a single wallpaper on every workspace instead — the
+switcher then shows one slot rather than ten, and changing workspace no longer
+changes the wallpaper.
+
+The mode is stored per monitor, in the same file as its wallpapers:
+
+```conf
+# ~/.config/hypr/wallpaper-daemon/config/<monitor>/defaults.conf
+mode=global
+global=$HOME/.config/wallpapers/defaults/images_sfw/wallpaper.jpg
+w-1=...
+```
+
+Per-workspace assignments are kept while global mode is on, so switching back
+restores them. From a script: `set-wallpaper.sh --mode global|workspace` and
+`set-wallpaper.sh global <monitor> <wallpaper>`.
+
 ### Wallpaper Engine Wallpapers
 
 Wallpaper Engine items subscribed through Steam are rendered by

--- a/docs/06_VISUAL_STYLING.md
+++ b/docs/06_VISUAL_STYLING.md
@@ -369,6 +369,34 @@ wallpaper = DP-1,$HOME/.config/wallpapers/background.png
 
 The blur effect uses your wallpaper as a base for the blur.
 
+### Wallpaper Engine Wallpapers
+
+Wallpaper Engine items subscribed through Steam are rendered by
+[kirie](https://github.com/UnhingedSoftware/kirie), installed into
+`~/.local/bin` by the install and update scripts. Without it, everything below
+is simply hidden.
+
+Picking one is the same as picking an image: open the switcher with
+`SUPER` + `W` and choose the **wallpaper engine** category. The daemon then
+routes that wallpaper to the engine instead of hyprpaper, and picking a plain
+image again hands the monitor back.
+
+| What | Where |
+|---|---|
+| Per-wallpaper settings (bloom, colours, speeds…) | Right-click the wallpaper in `SUPER` + `W` |
+| Engine settings (frame rate, GPU, volume, scaling…) | Wallpaper Engine section of `SUPER` + `L` |
+| Saved per-wallpaper settings | `~/.config/ags/cache/wallpaper-engine/<item id>.json` |
+| Engine control | `~/.config/hypr/wallpaper-daemon/kirie.sh` |
+| Engine log | `$XDG_RUNTIME_DIR/kirie.log` |
+
+One engine process serves every monitor, so changing workspace swaps the
+wallpaper over the engine's control socket rather than restarting it. Settings
+that can only be read at startup — GPU, layer, particles — say so in their
+tooltip and take effect on **Restart Engine**.
+
+The theme pipeline uses the item's preview image, so colours follow a
+Wallpaper Engine wallpaper exactly as they follow a static one.
+
 ## Performance Optimization
 
 ### If Your System Struggles:


### PR DESCRIPTION
Adds Wallpaper Engine support through [kirie](https://github.com/UnhingedSoftware/kirie), a Wayland renderer for its wallpapers, installed from its releases by the maintenance script.

The switcher gains per-wallpaper settings, a Steam Workshop browser to find and subscribe to new ones, an order control, and a right-click menu to manage them. All of it stays hidden unless kirie and Wallpaper Engine are both present.

![switcher](https://raw.githubusercontent.com/beingsuz/ArchEclipse/pr-assets/switcher.png)

| Workshop browser | Wallpaper Engine settings |
|:-:|:-:|
| ![workshop](https://raw.githubusercontent.com/beingsuz/ArchEclipse/pr-assets/workshop.png) | ![settings](https://raw.githubusercontent.com/beingsuz/ArchEclipse/pr-assets/settings.png) |
